### PR TITLE
String literals support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@ To run the REPL just enter the following in the source code directory
 and start typing REPL commands there. The syntax of the REPL commands is
 
     <repl-command> := <term> | <binding>
-    <term> ::= <numeric-literal> | <variable> | <function> | <application>
+    <term> ::= <variable> |
+               <numeric-literal> |
+               <string-literal> |
+               <function> |
+               <application>
     <binding> ::= <variable> := <term>
 
     <numeric-literal> ::= [0-9]+
+    <string-literal> ::= <java-string-literal>
     <variable> ::= [a-zA-Z][a-zA-Z0-9]*
     <function> ::= ( <lambda-symbol> . <variable> <term> )
     <application> ::= ( <term> <term> )

--- a/kernel/src/main/scala/me/rexim/morganey/church/ChurchNumberConverter.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/church/ChurchNumberConverter.scala
@@ -7,6 +7,8 @@ import scala.annotation.tailrec
 
 object ChurchNumberConverter {
 
+  private val printableChars = Set(32 to 176 :_*).map(_.toChar)
+
   @tailrec
   private def unwrapNumber(f: String, x: String, number: LambdaTerm, acc: Int = 0): Option[Int] = {
     number match {
@@ -33,5 +35,9 @@ object ChurchNumberConverter {
 
   def encodeNumber(number: Int): LambdaTerm = {
     lnested(List("f", "x"), wrapNumber(number))
+  }
+
+  def decodeChar(term: LambdaTerm): Option[Char] = {
+    decodeNumber(term).map(_.toChar) filter (printableChars.contains _)
   }
 }

--- a/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
@@ -2,7 +2,7 @@ package me.rexim.morganey.church
 
 import me.rexim.morganey.ast.{LambdaApp, LambdaFunc, LambdaVar, LambdaTerm}
 import me.rexim.morganey.ast.LambdaTerm
-import me.rexim.morganey.church.ChurchNumberConverter.decodeNumber
+import me.rexim.morganey.church.ChurchNumberConverter.{decodeNumber, encodeNumber}
 import me.rexim.morganey.util._
 
 object ChurchPairConverter {
@@ -40,8 +40,14 @@ object ChurchPairConverter {
     sequence(decodeResults)
   }
 
+  def encodeListOfNumbers(xs: List[Int]): Option[LambdaTerm] = 
+    encodeList(xs.map(encodeNumber))
+
   def decodeString(s: LambdaTerm): Option[String] =
     decodeListOfNumbers(s).map {
       xs => xs.map(_.toChar).mkString
     }
+
+  def encodeString(s: String): Option[LambdaTerm] =
+    encodeListOfNumbers(s.toList.map(_.toInt))
 }

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -30,7 +30,7 @@ class LambdaParser extends JavaTokenParsers {
       case IntMatcher(x) => ChurchNumberConverter.encodeNumber(x)
     }, { (rawInt) => s"`$rawInt' is too big"})
 
-  def morganeyStringLiteral: Parser[LambdaTerm] =
+  def stringLiteralTerm: Parser[LambdaTerm] =
     stringLiteral ^^ {
       case s => {
         ChurchPairConverter.encodeString(unquoteString(s)).get
@@ -50,7 +50,7 @@ class LambdaParser extends JavaTokenParsers {
   }
 
   def term: Parser[LambdaTerm] =
-    variable | numericLiteral | morganeyStringLiteral | func | application
+    variable | numericLiteral | stringLiteralTerm | func | application
 
   def binding: Parser[MorganeyBinding] =
     variable ~ ":=" ~ term ^^ {

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -11,4 +11,19 @@ package object util {
       case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
     }
 
+  def unquoteString(s: String): String =
+    if (s.isEmpty) s else s(0) match {
+      case '"' => unquoteString(s.tail)
+      case '\\' => s(1) match {
+        case 'b' => '\b' + unquoteString(s.drop(2))
+        case 'f' => '\f' + unquoteString(s.drop(2))
+        case 'n' => '\n' + unquoteString(s.drop(2))
+        case 'r' => '\r' + unquoteString(s.drop(2))
+        case 't' => '\t' + unquoteString(s.drop(2))
+        case '"' => '"'  + unquoteString(s.drop(2))
+        case 'u' => Integer.parseInt(s.drop(2).take(4), 16).toChar + unquoteString(s.drop(6))
+        case c => c + unquoteString(s.drop(2))
+      }
+      case c => c + unquoteString(s.tail)
+    }
 }

--- a/macros/src/main/scala/me/rexim/morganey/meta/Unliftable.scala
+++ b/macros/src/main/scala/me/rexim/morganey/meta/Unliftable.scala
@@ -1,7 +1,7 @@
 package me.rexim.morganey.meta
 
 import me.rexim.morganey.ast.LambdaTerm
-import me.rexim.morganey.church.ChurchNumberConverter.decodeNumber
+import me.rexim.morganey.church.ChurchNumberConverter.{decodeNumber, decodeChar}
 import me.rexim.morganey.church.ChurchPairConverter.{decodeList, decodePair}
 import me.rexim.morganey.util.sequence
 
@@ -14,12 +14,8 @@ trait Unliftable[T] {
 
 trait DefaultUnliftableInstances {
 
-  private val chars = Set(0 to 10 :_*).map(_.toChar)
-
   implicit val unliftInt = Unliftable[Int](decodeNumber)
-  implicit val unliftChar = Unliftable[Char] { t =>
-    decodeNumber(t).map(_.toChar) filter (chars.contains _)
-  }
+  implicit val unliftChar = Unliftable[Char](decodeChar)
 
   implicit val unliftString = Unliftable[String] { s =>
     val unlift = implicitly[Unliftable[Seq[Char]]]


### PR DESCRIPTION
We use Java-style string syntax. Double quotes `"` enclosing a sequence of:
- Any character except double quotes, control characters or backslash `\`
- A backslash followed by another backslash, a single or double quote, or one of the letters `b`, `f`, `n`, `r` or `t`
- `\` followed by `u` followed by four hexadecimal digits

Close #58 
