### PR TITLE
Add character literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ To run the REPL just enter the following in the source code directory
 and start typing REPL commands there. The syntax of the REPL commands is
 
     <repl-command> := <term> | <binding>
-    <term> ::= <variable> |
-               <numeric-literal> |
-               <string-literal> |
-               <function> |
-               <application>
+    <term> ::= <variable>
+             | <numeric-literal>
+             | <character-literal>
+             | <string-literal>
+             | <function>
+             | <application>
     <binding> ::= <variable> := <term>
 
     <numeric-literal> ::= [0-9]+
+    <character-literal> ::= '[\u0020-\u00B0]' | '\\[\\'"bfnrt]'
     <string-literal> ::= <java-string-literal>
     <variable> ::= [a-zA-Z][a-zA-Z0-9]*
     <function> ::= ( <lambda-symbol> . <variable> <term> )

--- a/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
@@ -13,4 +13,51 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
     term.successful should be (true)
     term.get should be (LambdaApp(I(x), I(y)))
   }
+
+  private val parse = LambdaParser.parseAll(LambdaParser.term, _: String)
+
+  private val validPrograms = Seq(
+    // string-literals
+    """"Hello!"""",
+    """"\tFoo\nBar!\n"""",
+    "\"\\\"\"",
+    "\"\\\'\"",
+
+    // char-literals
+    """'a'""",
+    """'\n'""",
+    """'''""",
+    """'\''""",
+    """'\"'""",
+    """'"'""",
+
+    // number-literals
+    "0",
+    "6",
+    "42",
+
+    "(λa.b)", "(a b)",
+    "(λa.(a b))", "((a b) (a b))"
+  )
+
+  for (program <- validPrograms) {
+    "Morganeys parser" should s"parse the valid program <$program> without any error" in {
+      parse(program).successful should be (true)
+    }
+  }
+
+  private val invalidPrograms = Seq(
+    "\"Hello",
+    "'a",
+    "(a b",
+    "(a . b)",
+    "(\\\\a . b)"
+  )
+
+  for (program <- invalidPrograms) {
+    "Morganeys parser" should s"parse the invalid program <$program> with a parse-error" in {
+      parse(program).successful should be(false)
+    }
+  }
+
 }


### PR DESCRIPTION
Allowed character literals:
- single chars (e.g. `'a'`, `'b'`, `'!'`)
- escaped chars `'\n'`, `'\b'`, `'\f'`, `'\r'`, `'\t'`
- `'''` and `'"'` do work, too

Close #65 
