### PR TITLE
Comments in scripts and terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ entered lambda term.
 
 To quit the REPL just `^C` it.
 
+### Comments ###
+
+In Morganey there are two types of comments: single-line (starting
+with double slash `//`, extending to the end of the line) and
+multi-line comments (any text, surrounded by `/*` and `*/`).
+
 ### Unit Tests ###
 
 To run the Unit Tests enter the following in the source code directory

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -19,6 +19,9 @@ object LambdaParser extends LambdaParser
 
 class LambdaParser extends JavaTokenParsers {
 
+  /* comment-regex taken from: http://stackoverflow.com/a/5954831 */
+  protected override val whiteSpace = """(\s|//.*|(?m)/\*(\*(?!/)|[^*])*\*/)+""".r
+
   def variable: Parser[LambdaVar] = {
     "[a-zA-Z][a-zA-Z0-9]*".r ^^ {
       name => LambdaVar(name)

--- a/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
@@ -16,6 +16,20 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
 
   private val parse = LambdaParser.parseAll(LambdaParser.term, _: String)
 
+  "A program just containing comments" should "be a valid (but empty) program" in {
+    val program =
+      """
+        | /*
+        |  * This is an empty program
+        |  */
+        | // (\x.x)
+      """.stripMargin
+
+    val result = LambdaParser.parseAll(LambdaParser.script, program)
+    result.successful should be (true)
+    result.get        should be (Nil)
+  }
+
   private val validPrograms = Seq(
     // string-literals
     """"Hello!"""",
@@ -30,6 +44,15 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
     """'\''""",
     """'\"'""",
     """'"'""",
+
+    // comments
+    "variable // this single-line comment is on the same line as a simple term",
+    """
+      |(\x . /*
+      | * This multi-line comment is in the middle
+      | * of a lambda-application.
+      | */ x)
+    """.stripMargin,
 
     // number-literals
     "0",


### PR DESCRIPTION
Added C-like comments:

``` scala
// single-line and

/*
  multi-
  line
  comments
*/
```

Close #28 
