### PR TITLE
Fix bug where REPL accepts on successful prefix-match

### DIFF
--- a/src/main/scala/me/rexim/morganey/Main.scala
+++ b/src/main/scala/me/rexim/morganey/Main.scala
@@ -39,8 +39,8 @@ object Main extends SignalHandler {
   }
 
   def handleLine(con: ConsoleReader)(globalContext: InterpreterContext, line: String): Option[InterpreterContext] = {
-    import LambdaParser.{parse, replCommand}
-    val nodeParseResult = parse(replCommand, line)
+    import LambdaParser.{parseAll, replCommand}
+    val nodeParseResult = parseAll(replCommand, line)
 
     if (nodeParseResult.successful) {
       val node = nodeParseResult.get


### PR DESCRIPTION
It should read the full input instead.
#91
