### PR TITLE
Fix small bug in README.md: syntax of abstraction in BNF

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and start typing REPL commands there. The syntax of the REPL commands is
     <character-literal> ::= '[\u0020-\u00B0]' | '\\[\\'"bfnrt]'
     <string-literal> ::= <java-string-literal>
     <variable> ::= [a-zA-Z][a-zA-Z0-9]*
-    <function> ::= ( <lambda-symbol> . <variable> <term> )
+    <function> ::= ( <lambda-symbol> <variable> . <term> )
     <application> ::= ( <term> <term> )
     <lambda-symbol> ::= λ | \
 


### PR DESCRIPTION
``` diff
-    <function> ::= ( <lambda-symbol> . <variable> <term> )
+    <function> ::= ( <lambda-symbol> <variable> . <term> )
```
