### PR TITLE
Reuse LambdaParser in ReplAutocompletion

### DIFF
--- a/kernel/src/main/scala/me/rexim/morganey/ast/MorganeyLoading.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/ast/MorganeyLoading.scala
@@ -1,5 +1,5 @@
 package me.rexim.morganey.ast
 
-case class MorganeyLoading(modulePath: String) extends MorganeyNode {
-  override def toString = s"load $modulePath"
+case class MorganeyLoading(modulePath: Option[String]) extends MorganeyNode {
+  override def toString = modulePath.map(path => s"load $path").getOrElse("invalid load")
 }

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -49,7 +49,7 @@ class LambdaParser extends JavaTokenParsers with ImplicitConversions {
   private def lambda = lambdaLetter | lambdaSlash
 
   private def parenthesis[T](p: Parser[T]): Parser[T] =
-    leftParentheis ~> p <~ rightParentheis
+    leftParenthesis ~> p <~ rightParenthesis
 
   def func: Parser[LambdaFunc] =
     parenthesis((lambda ~> variable) ~ (abstractionDot ~> term)) ^^ { LambdaFunc }

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -6,6 +6,7 @@ import me.rexim.morganey.util._
 import me.rexim.morganey.syntax.Language._
 
 import scala.util.parsing.combinator._
+import scala.language.postfixOps
 
 object IntMatcher {
   def unapply(rawInt: String): Option[Int] =
@@ -63,7 +64,7 @@ class LambdaParser extends JavaTokenParsers with ImplicitConversions {
     (variable <~ bindingAssign) ~ term ^^ { MorganeyBinding }
 
   def loading: Parser[MorganeyLoading] =
-    loadKeyword ~> modulePath.r ^^ { MorganeyLoading }
+    loadKeyword ~> (modulePath.r ?) ^^ { MorganeyLoading }
 
   def replCommand: Parser[MorganeyNode] = loading | binding | term
 

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -34,8 +34,8 @@ object Language {
 
   val whiteSpacePattern  = """(\s|//.*|(?m)/\*(\*(?!/)|[^*])*\*/)+"""
 
-  val leftParentheis     = "("
+  val leftParenthesis    = "("
 
-  val rightParentheis    = ")"
+  val rightParenthesis   = ")"
 
 }

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -1,0 +1,41 @@
+package me.rexim.morganey.syntax
+
+object Language {
+
+  val identifier         = "[a-zA-Z][a-zA-Z0-9]*"
+
+  val numberLiteral      = "[0-9]+"
+
+  val escapedCharLiteral = """'\\[\\'"bfnrt]'"""
+
+  val symbolCharLiteral  = "'[\u0020-\u00B0]'"
+
+  val modulePath         = "[a-zA-Z][a-zA-Z0-9.]*"
+
+  /** For handling escape sequences, which are currently supported as `characterLiteral` */
+  val escapeSequences =
+    Map[Char, Char](
+      'b' -> '\b',
+      'f' -> '\f',
+      'n' -> '\n',
+      'r' -> '\r',
+      't' -> '\t'
+    ) withDefault identity
+
+  val lambdaLetter       = "λ"
+
+  val lambdaSlash        = "\\"
+
+  val loadKeyword        = "load"
+
+  val bindingAssign      = ":="
+
+  val abstractionDot     = "."
+
+  val whiteSpacePattern  = """(\s|//.*|(?m)/\*(\*(?!/)|[^*])*\*/)+"""
+
+  val leftParentheis     = "("
+
+  val rightParentheis     = ")"
+
+}

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -36,6 +36,6 @@ object Language {
 
   val leftParentheis     = "("
 
-  val rightParentheis     = ")"
+  val rightParentheis    = ")"
 
 }

--- a/kernel/src/main/scala/me/rexim/morganey/util/InputSource.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/InputSource.scala
@@ -1,0 +1,21 @@
+package me.rexim.morganey.util
+
+import java.io.Reader
+
+import scala.language.implicitConversions
+
+object InputSource {
+
+  implicit def fromString(string: String): InputSource =
+    StringSource(string)
+
+  implicit def fromReader(reader: Reader): InputSource =
+    ReaderSource(reader)
+
+}
+
+sealed trait InputSource
+
+case class StringSource(string: String) extends InputSource
+
+case class ReaderSource(reader: Reader) extends InputSource

--- a/src/main/scala/me/rexim/morganey/Main.scala
+++ b/src/main/scala/me/rexim/morganey/Main.scala
@@ -41,16 +41,19 @@ object Main extends SignalHandler {
 
   def handleLine(con: ConsoleReader)(globalContext: InterpreterContext, line: String): Option[InterpreterContext] = {
     val nodeParseResult = LambdaParser.parseWith(line, _.replCommand)
-    nodeParseResult.toOption flatMap { node =>
+
+    val evaluationResult = nodeParseResult flatMap { node =>
       val computation = evalOneNodeComputation(node)(globalContext)
-      awaitComputationResult(computation) match {
-        case Success(MorganeyEval(context, result)) =>
-          result.foreach(t => con.println(smartShowTerm(t)))
-          Some(context)
-        case Failure(e) =>
-          con.println(e.getMessage)
-          None
-      }
+      awaitComputationResult(computation)
+    }
+
+    evaluationResult match {
+      case Success(MorganeyEval(context, result)) =>
+        result.foreach(t => con.println(smartShowTerm(t)))
+        Some(context)
+      case Failure(e) =>
+        con.println(e.getMessage)
+        None
     }
   }
 

--- a/src/main/scala/me/rexim/morganey/Main.scala
+++ b/src/main/scala/me/rexim/morganey/Main.scala
@@ -9,6 +9,7 @@ import me.rexim.morganey.ReplHelper.smartShowTerm
 import me.rexim.morganey.ast._
 import me.rexim.morganey.reduction.Computation
 import me.rexim.morganey.syntax.LambdaParser
+import me.rexim.morganey.util._
 import sun.misc.{Signal, SignalHandler}
 
 import scala.concurrent.Await
@@ -39,13 +40,9 @@ object Main extends SignalHandler {
   }
 
   def handleLine(con: ConsoleReader)(globalContext: InterpreterContext, line: String): Option[InterpreterContext] = {
-    import LambdaParser.{parseAll, replCommand}
-    val nodeParseResult = parseAll(replCommand, line)
-
-    if (nodeParseResult.successful) {
-      val node = nodeParseResult.get
+    val nodeParseResult = LambdaParser.parseWith(line, _.replCommand)
+    nodeParseResult.toOption flatMap { node =>
       val computation = evalOneNodeComputation(node)(globalContext)
-
       awaitComputationResult(computation) match {
         case Success(MorganeyEval(context, result)) =>
           result.foreach(t => con.println(smartShowTerm(t)))
@@ -54,9 +51,6 @@ object Main extends SignalHandler {
           con.println(e.getMessage)
           None
       }
-    } else {
-      con.println(nodeParseResult.toString)
-      None
     }
   }
 

--- a/src/main/scala/me/rexim/morganey/ReplAutocompletion.scala
+++ b/src/main/scala/me/rexim/morganey/ReplAutocompletion.scala
@@ -4,9 +4,12 @@ import java.io.File
 import java.util.{List => Jlist}
 
 import jline.console.completer.Completer
-import me.rexim.morganey.ast.MorganeyBinding
+import me.rexim.morganey.ast._
 import me.rexim.morganey.module.ModuleFinder
 import me.rexim.morganey.interpreter.InterpreterContext
+import me.rexim.morganey.syntax.LambdaParser
+import me.rexim.morganey.syntax.Language.identifier
+import me.rexim.morganey.util._
 
 import scala.annotation.tailrec
 import scala.util.Try
@@ -49,7 +52,7 @@ class ReplAutocompletion(globalContext: () => InterpreterContext) extends Comple
       f.isDirectory || isMorganeyModule(f)
 
     def topLevelDefinitions() =
-      moduleFinder.paths.filter(validMorganeyElement)
+      moduleFinder.paths.flatMap(_.listFiles).filter(validMorganeyElement)
 
     // List(root-file-of-module-path, module-file or directory)
     def findAllModulesIn(path: String): List[(File, File)] =
@@ -80,26 +83,48 @@ class ReplAutocompletion(globalContext: () => InterpreterContext) extends Comple
       base.toURI().relativize(file.toURI()).getPath()
     }
 
+    def moduleName(file: File): String = {
+      val rawName = stripExtensionIfModuleFile(file).getName
+      val suffix = if (file.isDirectory) "." else ""
+      s"$rawName$suffix"
+    }
+
     (parts, endsWithDot) match {
       // load .|
       case (Nil, true)       => Nil
       // load a.b.|
       case (xs, true)        => everythingIn(xs)
       // load |
-      case (Nil, false)      => topLevelDefinitions().map(stripExtensionIfModuleFile).map(_.getName)
+      case (Nil, false)      => topLevelDefinitions().map(moduleName)
       // load math.ari|
-      case (xs :+ x, false)  => everythingIn(xs, s => s.toLowerCase startsWith x.toLowerCase)
+      case (xs :+ x, false)  => everythingIn(xs, _.toLowerCase startsWith x.toLowerCase)
     }
   }
 
   private object LoadStatement {
-    private val loadStatement = "load (.*)".r
+    val zeroLoad = (Nil, false)
 
-    def unapply(line: String): Option[(List[String], Boolean)] =
-      Option(line) collect {
-        case loadStatement(modulePath) =>
-          (modulePath.split("\\.").toList, modulePath.endsWith("."))
+    def pathInformation(path: String) =
+      if (path.isEmpty) {
+        zeroLoad
+      } else if (path == ".") {
+        (Nil, true)
+      } else {
+        val pathElements = path.split("\\.", -1).toList
+        val endsWithDot  = pathElements.lastOption.exists(_.isEmpty)
+        val realPathElements =
+          if (endsWithDot) pathElements.init
+          else pathElements
+        (realPathElements, endsWithDot)
       }
+
+    def handleLoading(load: MorganeyLoading) =
+      load.modulePath map pathInformation getOrElse zeroLoad
+
+    def unapply(line: String): Option[(List[String], Boolean)] = {
+      val parseResult = LambdaParser.parseWith(line, _.loading).toOption
+      parseResult.map(handleLoading)
+    }
   }
 
   private def matchingDefinitions(line: String, knownVariableNames: List[String]): List[String] =
@@ -140,11 +165,9 @@ class ReplAutocompletion(globalContext: () => InterpreterContext) extends Comple
       .getOrElse(0)
   }
 
-  private val namePattern = "[a-zA-Z][a-zA-Z0-9]*"
-
   private def lastNameInLine(line: String): Option[String] = {
     def stringMatches(n: Int): Option[String] =
-      Option(line takeRight n).filter(_.matches(namePattern))
+      Option(line takeRight n).filter(_.matches(identifier))
 
     def size(str: Option[String]): Int =
       str.map(_.length).getOrElse(Int.MinValue)

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyInterpreter.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyInterpreter.scala
@@ -76,11 +76,7 @@ object MorganeyInterpreter {
     }
 
   def readNodes(reader: java.io.Reader): Try[List[MorganeyNode]] =
-    Try(LambdaParser.parseAll(LambdaParser.script, reader)).flatMap {
-      case parsedCode => parsedCode
-        .map(Success(_))
-        .getOrElse(Failure(new LambdaParserException(s"${parsedCode.toString}")))
-    }
+    LambdaParser.parseWith(reader, _.script)
 
   def readNodes(fileName: String): Try[List[MorganeyNode]] =
     withReader(fileName)(readNodes)

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyInterpreter.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyInterpreter.scala
@@ -50,10 +50,13 @@ object MorganeyInterpreter {
           MorganeyEval(context, Some(resultTerm))
         }
 
-      case MorganeyLoading(modulePath) => {
-        context.moduleFinder.findModuleFile(modulePath) match {
-          case Some(moduleFile) => loadFile(context)(moduleFile)
-          case None => Computation.fromFuture(Future.failed(new IllegalArgumentException(s"$modulePath doesn't exist")))
+      case MorganeyLoading(optionalModulePath) => {
+        optionalModulePath match {
+          case Some(modulePath) => context.moduleFinder.findModuleFile(modulePath) match {
+            case Some(moduleFile) => loadFile(context)(moduleFile)
+            case None => Computation.failed(s"$modulePath doesn't exist", new IllegalArgumentException(_))
+          }
+          case None => Computation.failed("Module path was not specified!", new IllegalArgumentException(_))
         }
       }
     }

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyInterpreter.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyInterpreter.scala
@@ -54,9 +54,9 @@ object MorganeyInterpreter {
         optionalModulePath match {
           case Some(modulePath) => context.moduleFinder.findModuleFile(modulePath) match {
             case Some(moduleFile) => loadFile(context)(moduleFile)
-            case None => Computation.failed(s"$modulePath doesn't exist", new IllegalArgumentException(_))
+            case None => Computation.failed(new IllegalArgumentException(s"$modulePath doesn't exist"))
           }
-          case None => Computation.failed("Module path was not specified!", new IllegalArgumentException(_))
+          case None => Computation.failed(new IllegalArgumentException("Module path was not specified!"))
         }
       }
     }

--- a/src/main/scala/me/rexim/morganey/reduction/Computation.scala
+++ b/src/main/scala/me/rexim/morganey/reduction/Computation.scala
@@ -30,6 +30,6 @@ object Computation {
     override def future: Future[T] = f
   }
 
-  def failed[T](message: String, exception: String => Throwable): Computation[T] =
-    fromFuture(Future.failed(exception(message)))
+  def failed[T](exception: Throwable): Computation[T] =
+    fromFuture(Future.failed(exception))
 }

--- a/src/main/scala/me/rexim/morganey/reduction/Computation.scala
+++ b/src/main/scala/me/rexim/morganey/reduction/Computation.scala
@@ -29,4 +29,7 @@ object Computation {
     override def cancel(): Unit = ()
     override def future: Future[T] = f
   }
+
+  def failed[T](message: String, exception: String => Throwable): Computation[T] =
+    fromFuture(Future.failed(exception(message)))
 }


### PR DESCRIPTION
Trial-implementation of issue #89.
@rexim @ForNeVeR your comments are very much appreciated!
## 

After separation of regex-patterns into an object, the regex for identifier can be reused in the ReplAutocompletion for variable names. As for the load-statement the parser had to be changed: Parsing of the module-path after the `load` keyword is now optional. The REPL has to check, if the module-path was given. During autocompletion the parser is used to verify load-statements, thanks to this change, too. 

However, if this PR is not merged, I suggest cherry-picking the abstractions `InputSource`, the implicit class in the util-package object (named `ParserOps`), which improves the usage of the parser, and the change in the file `Computation.scala`.
