### PR TITLE
Implement list literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,34 @@ To run the REPL just enter the following in the source code directory
 
 and start typing REPL commands there. The syntax of the REPL commands is
 
-    <repl-command> := <term> | <binding> | <loading>
+    <repl-command> := <term>
+                    | <binding>
+                    | <loading>
     <term> ::= <variable>
-             | <numeric-literal>
-             | <character-literal>
-             | <string-literal>
+             | <literal>
              | <function>
              | <application>
-    <binding> ::= <variable> := <term>
-    <loading> ::= load <module-path>
+    <binding> ::= <variable> ":=" <term>
+    <loading> ::= "load" <module-path>
     <module-path> := [a-zA-Z][a-zA-Z0-9.]*
 
+    <literal> ::= <numeric-literal>
+                | <character-literal>
+                | <string-literal>
+                | <list-literal>
     <numeric-literal> ::= [0-9]+
-    <character-literal> ::= '[\u0020-\u00B0]' | '\\[\\'"bfnrt]'
+    <character-literal> ::= '[\u0020-\u00B0]'
+                          | '\\[\\'"bfnrt]'
     <string-literal> ::= <java-string-literal>
+    <list-literal> ::= "[" [ term { "," term } ] "]"
+                     | "[" <numeric-literal> [ "," <numeric-literal> ] ".." <numeric-literal> "]"
+                     | "[" <character-literal> [ "," <character-literal> ] ".." <character-literal> "]"
+
     <variable> ::= [a-zA-Z][a-zA-Z0-9]*
-    <function> ::= ( <lambda-symbol> <variable> . <term> )
-    <application> ::= ( <term> <term> )
-    <lambda-symbol> ::= λ | \
+    <function> ::= "(" <lambda-symbol> <variable> "." <term> ")"
+    <application> ::= "(" <term> <term> ")"
+    <lambda-symbol> ::= "λ"
+                      | "\"
 
 The REPL will take the entered lambda term, beta-reduce it with the
 normal order reduction strategy and output the normal form of the

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -53,7 +53,7 @@ class LambdaParser extends JavaTokenParsers with ImplicitConversions {
 
   private def range[T](p: => Parser[T])(implicit ev: Integral[T]): Parser[LambdaTerm] = {
     val q = p
-    val parser = q ~ opt(comma ~> q) ~ (dotDot ~> q)
+    val parser = q ~ opt(comma ~> q) ~ (rangeOperator ~> q)
     parser ^^ { case start ~ next ~ exit =>
       val step  = next.map(ev.minus(_, start)).getOrElse(ev.one)
       val range = NumericRange.inclusive(start, exit, step).toList

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -44,6 +44,6 @@ object Language {
 
   val rightBracket       = "]"
 
-  val dotDot             = ".."
+  val rangeOperator      = ".."
 
 }

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -32,10 +32,18 @@ object Language {
 
   val abstractionDot     = "."
 
+  val comma              = ","
+
   val whiteSpacePattern  = """(\s|//.*|(?m)/\*(\*(?!/)|[^*])*\*/)+"""
 
   val leftParenthesis    = "("
 
   val rightParenthesis   = ")"
+
+  val leftBracket        = "["
+
+  val rightBracket       = "]"
+
+  val dotDot             = ".."
 
 }


### PR DESCRIPTION
closes #66
## 
- Lists can be specified as ranges of characters and numbers (`[1 .. 10]`, `[1, 3 .. 10]`, `[10, 8 .. 0]`)
- List literals for arbitrary terms (`[]`, `[1]`, `[[]]`, `["foo", 'b', ['a', 'r']]`)
