### PR TITLE
Shorter syntax for lambda terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ and start typing REPL commands there. The syntax of the REPL commands is
     <repl-command> := <term>
                     | <binding>
                     | <loading>
-    <term> ::= <variable>
-             | <literal>
-             | <function>
+    <term> ::= <function>
              | <application>
+             | <literal>
+             | <variable>
+             | "(" <term> ")"
     <binding> ::= <variable> ":=" <term>
     <loading> ::= "load" <module-path>
     <module-path> := [a-zA-Z][a-zA-Z0-9.]*
@@ -44,8 +45,8 @@ and start typing REPL commands there. The syntax of the REPL commands is
                             | <character-literal>
 
     <variable> ::= [a-zA-Z][a-zA-Z0-9]*
-    <function> ::= "(" <lambda-symbol> <variable> "." <term> ")"
-    <application> ::= "(" <term> <term> ")"
+    <function> ::= <lambda-symbol> <variable> "." { <variable> "." } <term>
+    <application> ::= <term> <term> { <term> }
     <lambda-symbol> ::= "λ"
                       | "\"
 

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -98,7 +98,7 @@ class LambdaParser extends JavaTokenParsers with ImplicitConversions {
     loadKeyword ~> (modulePath.r ?) ^^ { MorganeyLoading }
 
   def replCommand: Parser[MorganeyNode] =
-    withLnBreaks(loading | binding | term)
+    loading | binding | term
 
   def script: Parser[List[MorganeyNode]] =
     withLnBreaks(repsep(replCommand, newLines))

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -34,7 +34,10 @@ object Language {
 
   val comma              = ","
 
-  val whiteSpacePattern  = """(\s|//.*|(?m)/\*(\*(?!/)|[^*])*\*/)+"""
+  /* comment-regex taken from: http://stackoverflow.com/a/5954831 */
+  val whiteSpacePattern  = """([ \t]|//.*|(?m)/\*(\*(?!/)|[^*]|[\n\r])*\*/)+"""
+
+  val lineBreak          = "[\n\r]"
 
   val leftParenthesis    = "("
 


### PR DESCRIPTION
The parser now parses the new notation introduced in #67.  
## 

TODO:
- [x] Change parser
- [x] Update docs
- [x] Add new tests
## 

Edits:
- This PR is not blocked #123 anymore after closing of #125
- Remove `Update / Port std-lib` from the list of todos, create issue #129
## 

closes #67
