### PR TITLE
Empty list semantic for LambdaInput

### DIFF
--- a/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
@@ -70,9 +70,8 @@ case class LambdaInput(input: Stream[Char]) extends LambdaTerm {
 
   override def substitute(substitution: (LambdaVar, LambdaTerm)): LambdaTerm =
     input match {
-      case Stream(x) => encodeNumber(x.toInt)
       case x #:: xs => encodePair((encodeNumber(x.toInt), LambdaInput(xs))).substitute(substitution)
-      case _ => ???  // FIXME: This is just getting ridiculous! Please implement #62 already! :D
+      case _ => encodeList(List())
     }
 
   override val toString = "<input>"

--- a/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
@@ -69,8 +69,15 @@ case class LambdaInput(input: Stream[Char]) extends LambdaTerm {
   override val freeVars: Set[String] = Set()
 
   override def substitute(substitution: (LambdaVar, LambdaTerm)): LambdaTerm =
+    forceNextChar().substitute(substitution)
+
+  /**
+    * Forces next character in the input to be Church encoded and
+    * put at the begining of the virtual input list
+    */
+  def forceNextChar(): LambdaTerm =
     input match {
-      case x #:: xs => encodePair((encodeNumber(x.toInt), LambdaInput(xs))).substitute(substitution)
+      case x #:: xs => encodePair((encodeNumber(x.toInt), LambdaInput(xs)))
       case _ => encodeList(List())
     }
 

--- a/src/main/scala/me/rexim/morganey/reduction/CallByName.scala
+++ b/src/main/scala/me/rexim/morganey/reduction/CallByName.scala
@@ -1,6 +1,6 @@
 package me.rexim.morganey.reduction
 
-import me.rexim.morganey.ast.{LambdaFunc, LambdaApp, LambdaTerm}
+import me.rexim.morganey.ast._
 
 object CallByName {
   implicit class CallByNameStrategy(val term: LambdaTerm) {
@@ -15,12 +15,14 @@ object CallByName {
     def cbnStepReduce(): LambdaTerm = term match {
       case LambdaApp(LambdaFunc(x, t), r) => t.substitute(x -> r)
       case LambdaApp(l, r) => LambdaApp(l.cbnStepReduce(), r)
+      case input: LambdaInput => input.forceNextChar()
       case other => other
     }
 
     def cbnIsFinished(): Boolean = term match {
       case LambdaApp(LambdaFunc(_, _), _) => false
       case LambdaApp(l, _) => l.cbnIsFinished()
+      case _: LambdaInput => false
       case _ => true
     }
   }

--- a/src/main/scala/me/rexim/morganey/reduction/NormalOrder.scala
+++ b/src/main/scala/me/rexim/morganey/reduction/NormalOrder.scala
@@ -1,6 +1,6 @@
 package me.rexim.morganey.reduction
 
-import me.rexim.morganey.ast.{LambdaApp, LambdaFunc, LambdaTerm}
+import me.rexim.morganey.ast._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
@@ -42,6 +42,7 @@ object NormalOrder {
       case LambdaApp(l, r) if !l.norIsFinished() => LambdaApp(l.norStepReduce(), r)
       case LambdaApp(l, r) if !r.norIsFinished() => LambdaApp(l, r.norStepReduce())
       case LambdaFunc(x, t) => LambdaFunc(x, t.norStepReduce())
+      case input: LambdaInput => input.forceNextChar()
       case other => other
     }
 
@@ -49,6 +50,7 @@ object NormalOrder {
       case LambdaApp(LambdaFunc(_, _), _) => false
       case LambdaApp(l, r) => l.norIsFinished() && r.norIsFinished()
       case LambdaFunc(_, t) => t.norIsFinished()
+      case _: LambdaInput => false
       case _ => true
     }
   }

--- a/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
+++ b/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
@@ -24,7 +24,7 @@ class LambdaInputSpecs extends FlatSpec with Matchers with TestTerms {
     firstChar should be (Some('k'))
   }
 
-  "Empty lambda input" should "should be evaluated to an empty list" in {
+  "Empty lambda input" should "be evaluated to an empty list" in {
     decodeList(emptyInput.forceNextChar()) should be (Some(List()))
   }
 }

--- a/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
+++ b/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
@@ -10,6 +10,7 @@ import org.scalatest._
 class LambdaInputSpecs extends FlatSpec with Matchers with TestTerms {
   val longInput = LambdaInput("khooy".toStream)
   val singleCharInput = LambdaInput("k".toStream)
+  val emptyInput = LambdaInput(Stream.empty)
 
   "Lambda input" should "have zero free vars by definition" in {
     longInput.freeVars.isEmpty should be (true)
@@ -23,14 +24,7 @@ class LambdaInputSpecs extends FlatSpec with Matchers with TestTerms {
     firstChar should be (Some('k'))
   }
 
-  "Lambda input with single character" should "be evaluated to a single character" in {
-    val forcedInput = decodeChar(singleCharInput.substitute(lvar("x") -> lvar("x")))
-    forcedInput should be (Some('k'))
-  }
-
-  "Empty lambda input" should "stay unimplemented because of Morganey lists nature" in {
-    intercept[NotImplementedError] {
-      LambdaInput(Stream.empty).substitute(lvar("x") -> lvar("x"))
-    }
+  "Empty lambda input" should "should be evaluated to an empty list" in {
+    decodeList(emptyInput.substitute(lvar("x") -> lvar("x"))) should be (Some(List()))
   }
 }

--- a/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
+++ b/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
@@ -17,7 +17,7 @@ class LambdaInputSpecs extends FlatSpec with Matchers with TestTerms {
   }
 
   "Lambda input" should "be lazily evaluated to a pair when substituted" in {
-    val forcedInput = decodePair(longInput.substitute(lvar("x") -> lvar("x")))
+    val forcedInput = decodePair(longInput.forceNextChar())
     forcedInput.isDefined should be (true)
 
     val firstChar = decodeChar(forcedInput.get._1)
@@ -25,6 +25,6 @@ class LambdaInputSpecs extends FlatSpec with Matchers with TestTerms {
   }
 
   "Empty lambda input" should "should be evaluated to an empty list" in {
-    decodeList(emptyInput.substitute(lvar("x") -> lvar("x"))) should be (Some(List()))
+    decodeList(emptyInput.forceNextChar()) should be (Some(List()))
   }
 }

--- a/src/test/scala/me/rexim/morganey/reduction/CallByNameSpec.scala
+++ b/src/test/scala/me/rexim/morganey/reduction/CallByNameSpec.scala
@@ -1,5 +1,8 @@
 package me.rexim.morganey.reduction
 
+import me.rexim.morganey.ast._
+import me.rexim.morganey.church.ChurchPairConverter._
+import me.rexim.morganey.church.ChurchNumberConverter._
 import me.rexim.morganey.ast.LambdaTermHelpers._
 import me.rexim.morganey.helpers.TestTerms
 import me.rexim.morganey.reduction.CallByName._
@@ -44,5 +47,10 @@ class CallByNameSpec extends FlatSpec with Matchers with TestTerms {
 
   "Term with redices" should "be reduced until there are redices in head position" in {
     redex(redex(redex(funcWithRedexBody))).cbnReduce() should be (funcWithRedexBody)
+  }
+
+  "Input term" should "be evaluated once by the strategy" in {
+    val input = "abc"
+    decodePair(LambdaInput(input.toStream).cbnReduce()) should be (Some((encodeNumber('a'.toInt), LambdaInput(input.tail.toStream))))
   }
 }

--- a/src/test/scala/me/rexim/morganey/reduction/NormalOrderSpec.scala
+++ b/src/test/scala/me/rexim/morganey/reduction/NormalOrderSpec.scala
@@ -1,8 +1,10 @@
 package me.rexim.morganey.reduction
 
+import me.rexim.morganey.ast.LambdaInput
 import me.rexim.morganey.ast.LambdaTermHelpers._
 import me.rexim.morganey.reduction.NormalOrder._
 import me.rexim.morganey.helpers.TestTerms
+import me.rexim.morganey.church.ChurchPairConverter._
 import org.scalatest._
 
 class NormalOrderSpec extends FlatSpec with Matchers with TestTerms {
@@ -34,5 +36,10 @@ class NormalOrderSpec extends FlatSpec with Matchers with TestTerms {
     val expectedTerm = lfunc("x", lapp(x, y))
 
     inputTerm.norReduce() should be (expectedTerm)
+  }
+
+  "Input term" should "full evaluated by the strategy" in {
+    val input = "abc"
+    decodeString(new LambdaInput(input.toStream).norReduce()) should be (Some(input))
   }
 }


### PR DESCRIPTION
Close #133 

Also made all of the supported reduction strategies treat LambdaInput as a beta-redex, which is useful when result of the program evaluations contains unevaluated input. For example, program like 

```
main := \input . input
```

Will correctly output everything it recieves on the input.
