### PR TITLE
Smartdetection using Unliftable

### DIFF
--- a/macros/src/main/scala/me/rexim/morganey/meta/Liftable.scala
+++ b/macros/src/main/scala/me/rexim/morganey/meta/Liftable.scala
@@ -31,6 +31,8 @@ trait DefaultLiftableInstances {
       encodeList(ys.toList)
     }
 
+  implicit val liftId = Liftable[LambdaTerm](identity)
+
 }
 
 object Liftable {

--- a/macros/src/main/scala/me/rexim/morganey/meta/Unliftable.scala
+++ b/macros/src/main/scala/me/rexim/morganey/meta/Unliftable.scala
@@ -44,6 +44,9 @@ trait DefaultUnliftableInstances {
         }
       }
     }
+
+  implicit val unliftId = Unliftable[LambdaTerm](Some(_))
+
 }
 
 object Unliftable {

--- a/src/main/scala/me/rexim/morganey/interpreter/TermOutputHelper.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/TermOutputHelper.scala
@@ -3,38 +3,31 @@ package me.rexim.morganey.interpreter
 import me.rexim.morganey.ast.LambdaTerm
 import me.rexim.morganey.meta._
 
-import scala.annotation.tailrec
-
 object TermOutputHelper {
 
-  def smartShowTerm(term: LambdaTerm, noPrefix: Boolean = false): String = {
-    @tailrec
-    def decode(decoders: List[Decoder[_]]): String = decoders match {
-      case hd :: tl => hd(term) match {
-        case Some(result) => if (noPrefix) result else s"${hd.prefix}: $result"
-        case None         => decode(tl)
-      }
-      case Nil =>
-        // `idDecoder` won't ever return `None`
-        val result = idDecoder(term).get
-        if (noPrefix) result else s"${idDecoder.prefix}: $result"
-    }
-    decode(decoders)
+  def smartShowTerm(term: LambdaTerm): String = {
+    val (prefix, value) = decode(term)
+    s"$prefix: $value"
   }
 
-  private val idDecoder = Decoder[LambdaTerm]("term", _.toString)
+  private def decode(term: LambdaTerm): (String, String) =
+    decoders
+      .map(_(term))
+      .find(_.isDefined)
+      .flatten
+      .getOrElse(("term", term.toString))
 
-  private val decoders: List[Decoder[_]] =
-    List(
-      Decoder[Char]                     ("char", c => s"'$c'"),
-      Decoder[Int]                      ("number", _.toString),
-      Decoder[String]                   ("string", s => s"""\"$s\""""),
-      Decoder[Seq[Int]]                 ("numbers", _.mkString("[", ",", "]")),
-      Decoder[Seq[LambdaTerm]]          ("elements", _.map(smartShowTerm(_, true)).mkString("[", ",", "]"))
+  private val decoders: Stream[Decoder[_]] =
+    Stream(
+      Decoder[Char]            ("char", c => s"'$c'"),
+      Decoder[Int]             ("number", _.toString),
+      Decoder[String]          ("string", s => s"""\"$s\""""),
+      Decoder[Seq[Int]]        ("numbers", _.mkString("[", ",", "]")),
+      Decoder[Seq[LambdaTerm]] ("elements", _.map(decode(_)._2).mkString("[", ",", "]"))
     )
 
   private case class Decoder[T](prefix: String, transform: T => String)(implicit unT: Unliftable[T]) {
-    def apply(term: LambdaTerm): Option[String] = unT.unapply(term).map(transform)
+    def apply(term: LambdaTerm): Option[(String, String)] = unT.unapply(term).map(transform).map((prefix, _))
   }
 
 }

--- a/src/main/scala/me/rexim/morganey/interpreter/TermOutputHelper.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/TermOutputHelper.scala
@@ -22,7 +22,7 @@ object TermOutputHelper {
     decode(decoders)
   }
 
-  private implicit val idDecoder = Decoder[LambdaTerm]("term", _.toString)
+  private val idDecoder = Decoder[LambdaTerm]("term", _.toString)
 
   private val decoders: List[Decoder[_]] =
     List(

--- a/src/main/scala/me/rexim/morganey/interpreter/TermOutputHelper.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/TermOutputHelper.scala
@@ -30,8 +30,7 @@ object TermOutputHelper {
       Decoder[Int]                      ("number", _.toString),
       Decoder[String]                   ("string", s => s"""\"$s\""""),
       Decoder[Seq[Int]]                 ("numbers", _.mkString("[", ",", "]")),
-      Decoder[Seq[LambdaTerm]]          ("elements", _.map(smartShowTerm(_, true)).mkString("[", ",", "]")),
-      Decoder[(LambdaTerm, LambdaTerm)] ("pair", { case (a, b) => s"(${smartShowTerm(a, true)}, ${smartShowTerm(b, true)})" })
+      Decoder[Seq[LambdaTerm]]          ("elements", _.map(smartShowTerm(_, true)).mkString("[", ",", "]"))
     )
 
   private case class Decoder[T](prefix: String, transform: T => String)(implicit unT: Unliftable[T]) {

--- a/src/test/scala/me/rexim/morganey/interpreter/TermOutputHelperSpec.scala
+++ b/src/test/scala/me/rexim/morganey/interpreter/TermOutputHelperSpec.scala
@@ -12,7 +12,15 @@ class TermOutputHelperSpec extends FlatSpec with Matchers {
     m"5" -> "number: 5",
     m"[1, 2, 3]" -> "numbers: [1,2,3]",
     m"'x'" -> "char: 'x'",
-    m""""khooy"""" -> "string: \"khooy\""
+    m""""khooy"""" -> "string: \"khooy\"",
+    m"['a' .. 'f']" -> "string: \"abcdef\"",
+    m"['a','c' .. 'm']" -> "string: \"acegikm\"",
+    m"""["abc", "def"]""" -> "elements: [\"abc\",\"def\"]",
+    m"""[["abc", "def"]]""" -> "elements: [[\"abc\",\"def\"]]",
+    m"""[[1, 2, 3, 'a']]""" -> "elements: [[1,2,3,97]]",
+    m"""['A', [1, 2], 1]""" -> "elements: ['A',[1,2],1]",
+    m"""['A', ""]""" -> "numbers: [65,0]",
+    m"[[1, 'A'], []]" -> "elements: [[1,65],0]"
   )
 
   "A term" should "be correctly identified and showed" in {


### PR DESCRIPTION
Reimplementation of smartdetection of lambda terms in REPL, which provides:
- reduction of duplicate code: previously the detection of terms was implementet in `kernel` (`ChurchNumberConverter` and `ChurchPairConverter`) and in `src` (`TermOutputHelper`). Now it's only implemented in `kernel` and used (with the help of the `Unliftable`-typeclass) in `src`
- easier to add detection of different terms using `Unliftable`
- detection of nested terms:

```
\> ['a', [1, 2], ['a' .. 'c'], "foo", [1, 'a'], []]
elements: ['a',[1,2],"abc","foo",[1,97],0]
```

Copy and pasting the detected term is still possible.
## 

Because of this PR beeing a proposal, no additional unit tests for nested terms were added, yet.
## 

A potential problem with this implementation might arise, if #119 and #131 get implemented, because of the dependency of `TermOutputHelper` on `meta` (`Unliftable`-Typeclass).
## 

If this PR doesn't get merged, the reimplementation showed me, that I'd like to have the detection of nested terms in the REPL.
