### PR TITLE
Make REPL commands distinguishable from terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ and start entring REPL commands there. You can enter
 - `<term>` (see [Language](#language))
 - `<binding>` (see [Language](#language))
 - `<loading>` (see [Language](#language))
-- `exit` - exits the REPL
-- `reset` - clears the current context
+- `:exit` - exits the REPL
+- `:reset` - clears the current context
 
 The REPL will take the entered lambda term, beta-reduce it with the
 normal order reduction strategy and output the normal form of the

--- a/src/main/scala/me/rexim/morganey/Commands.scala
+++ b/src/main/scala/me/rexim/morganey/Commands.scala
@@ -1,0 +1,36 @@
+package me.rexim.morganey
+
+import me.rexim.morganey.interpreter.InterpreterContext
+
+object Commands {
+
+  final type Command = InterpreterContext => (InterpreterContext, Option[String])
+
+  val commandPattern  = ":([a-zA-Z]+)".r
+  val commandWithArgs = ":([a-zA-Z]+) (.*)".r
+
+  private val commands =
+    Map[String, String => Command](
+      "reset" -> resetBindings,
+      "exit" -> exitREPL
+    ) withDefault unknownCommand
+
+  def unapply(line: String): Option[Command] =
+    (line match {
+      case commandPattern(cmd)        => Some((cmd, ""))
+      case commandWithArgs(cmd, args) => Some((cmd, args))
+      case _                          => None
+    }).map {
+      case (cmd, args) => commands(cmd)(args)
+    }
+
+  private def unknownCommand(command: String)(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
+    (context, Some(s"Unknown command '$command'!"))
+
+  private def exitREPL(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
+    sys.exit(0)
+
+  private def resetBindings(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
+    (context.reset(), Some("Cleared all the bindings"))
+
+}

--- a/src/main/scala/me/rexim/morganey/Main.scala
+++ b/src/main/scala/me/rexim/morganey/Main.scala
@@ -71,13 +71,13 @@ object Main extends SignalHandler {
     val evalLine = handleLine(con) _
 
     while (running) line() match {
-      case None         => exitRepl() // eof
-      case Some("")     => ()
-      case Some("exit") => exitRepl()
-      case Some("reset") =>
-        con.println("Cleared all the bindings")
-        globalContext = globalContext.reset()
-      case Some(line)   => evalLine(globalContext, line) foreach { context =>
+      case None                => exitRepl() // eof
+      case Some("")            => ()
+      case Some(Commands(cmd)) =>
+        val (newContext, output) = cmd(globalContext)
+        globalContext = newContext
+        output.foreach(con.println)
+      case Some(line)          => evalLine(globalContext, line) foreach { context =>
         globalContext = context
       }
     }


### PR DESCRIPTION
- Commands are now prefixed with `:`
- Split commands to map to allow implementation of #87
## 

closes #83
