### PR TITLE
Add command for printing raw terms without detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ and start entring REPL commands there. You can enter
 - `<binding>` (see [Language](#language))
 - `<loading>` (see [Language](#language))
 - `:exit` - exits the REPL
+- `:raw` - prints the representation of the term
 - `:reset` - clears the current context
 
 The REPL will take the entered lambda term, beta-reduce it with the

--- a/src/main/scala/me/rexim/morganey/Commands.scala
+++ b/src/main/scala/me/rexim/morganey/Commands.scala
@@ -1,6 +1,10 @@
 package me.rexim.morganey
 
 import me.rexim.morganey.interpreter.InterpreterContext
+import me.rexim.morganey.syntax.LambdaParser
+import me.rexim.morganey.util._
+
+import scala.util.{Failure, Success}
 
 object Commands {
 
@@ -11,8 +15,9 @@ object Commands {
 
   private val commands =
     Map[String, String => Command](
-      "reset" -> resetBindings,
-      "exit" -> exitREPL
+      "exit"  -> exitREPL,
+      "raw"   -> rawPrintTerm,
+      "reset" -> resetBindings
     ) withDefault unknownCommand
 
   def unapply(line: String): Option[Command] =
@@ -29,6 +34,15 @@ object Commands {
 
   private def exitREPL(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
     sys.exit(0)
+
+  private def rawPrintTerm(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) = {
+    val parseResult = LambdaParser.parseWith(args, _.term)
+    val output = parseResult match {
+      case Success(term) => term.toString
+      case Failure(e)    => e.getMessage
+    }
+    (context, Option(output))
+  }
 
   private def resetBindings(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
     (context.reset(), Some("Cleared all the bindings"))


### PR DESCRIPTION
`:raw 1` will now print

```
\f.x.f x
```
## 

closes  #157
