### PR TITLE
Implement removing of specified bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ and start entring REPL commands there. You can enter
 - `<binding>` (see [Language](#language))
 - `<loading>` (see [Language](#language))
 - `:exit` - exits the REPL
-- `:raw` - prints the representation of the term
-- `:reset` - clears the current context
+- `:raw <term>` - prints the representation of the term
+- `:reset <regex>` - clears either the current context, or all bindings matching the regex
 
 The REPL will take the entered lambda term, beta-reduce it with the
 normal order reduction strategy and output the normal form of the

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -1,7 +1,8 @@
 package me.rexim.morganey
 
-import java.io.{FileInputStream, InputStreamReader, Reader, File}
+import java.io.{File, FileInputStream, InputStreamReader, Reader}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.regex.Pattern
 
 import scala.util._
 import me.rexim.morganey.syntax.{LambdaParser, LambdaParserException}
@@ -21,6 +22,12 @@ package object util {
     lst.foldRight(Try(List.empty[T])) {
       case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
     }
+
+  def validRegex(regex: String): Option[String => Boolean] =
+    Try {
+      val pattern = Pattern.compile(regex)
+      s: String => pattern.matcher(s).matches()
+    }.toOption
 
   def unquoteString(s: String): String =
     if (s.isEmpty) s else s(0) match {

--- a/kernel/src/test/scala/me/rexim/morganey/util/UtilSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/util/UtilSpec.scala
@@ -17,4 +17,13 @@ class UtilSpec extends FlatSpec with Matchers {
     sequence(someNums) should be (Some(numbers))
   }
 
+  "The validRegex function" should "give back a function to match strings, if a valid regex was given" in {
+    val matcher1 = validRegex("[a-zA-Z]+")
+    matcher1                      shouldBe a[Some[_]]
+    matcher1 exists (_("fooBar")) should be (true)
+
+    val matcher2 = validRegex("[*")
+    matcher2                      should be (None)
+  }
+
 }

--- a/src/main/scala/me/rexim/morganey/Commands.scala
+++ b/src/main/scala/me/rexim/morganey/Commands.scala
@@ -51,19 +51,22 @@ object Commands {
   private def resetBindings(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
     if (args.isEmpty) {
       (context.reset(), Some("Cleared all the bindings"))
-    } else {
-      val (newContext, removedBindings) = context.partitionBindings(b => !(b.variable.name matches args))
+    } else validRegex(args) match {
+      case None =>
+        (context, Some(s"'$args' is not a valid regular expression!"))
+      case Some(matcher) =>
+        val (newContext, removedBindings) = context.partitionBindings(b => !matcher(b.variable.name))
 
-      val removed = removedBindings.map(_.variable.name)
-      val message = removed match {
-        case Nil       => "No bindings were removed!"
-        case hd :: Nil => s"Binding '$hd' was removed!"
-        case in :+ ls  =>
-          val bindingEnumeration = in.map(b => s"'$b'").mkString(", ") + s" and '$ls'"
-          s"Bindings $bindingEnumeration were removed!"
-      }
+        val removed = removedBindings.map(_.variable.name)
+        val message = removed match {
+          case Nil       => "No bindings were removed!"
+          case hd :: Nil => s"Binding '$hd' was removed!"
+          case in :+ ls  =>
+            val bindingEnumeration = in.map(b => s"'$b'").mkString(", ") + s" and '$ls'"
+            s"Bindings $bindingEnumeration were removed!"
+        }
 
-      (newContext, Option(message))
+        (newContext, Option(message))
     }
 
 }

--- a/src/main/scala/me/rexim/morganey/Commands.scala
+++ b/src/main/scala/me/rexim/morganey/Commands.scala
@@ -1,5 +1,6 @@
 package me.rexim.morganey
 
+import me.rexim.morganey.ast.MorganeyBinding
 import me.rexim.morganey.interpreter.InterpreterContext
 import me.rexim.morganey.syntax.LambdaParser
 import me.rexim.morganey.util._
@@ -29,7 +30,7 @@ object Commands {
 
   def unapply(line: String): Option[Command] =
     parseCommand(line).map {
-      case (cmd, args) => commands(cmd)(args)
+      case (cmd, args) => commands(cmd)(args.trim)
     }
 
   private def unknownCommand(command: String)(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
@@ -48,6 +49,21 @@ object Commands {
   }
 
   private def resetBindings(args: String)(context: InterpreterContext): (InterpreterContext, Option[String]) =
-    (context.reset(), Some("Cleared all the bindings"))
+    if (args.isEmpty) {
+      (context.reset(), Some("Cleared all the bindings"))
+    } else {
+      val (newContext, removedBindings) = context.partitionBindings(b => !(b.variable.name matches args))
+
+      val removed = removedBindings.map(_.variable.name)
+      val message = removed match {
+        case Nil       => "No bindings were removed!"
+        case hd :: Nil => s"Binding '$hd' was removed!"
+        case in :+ ls  =>
+          val bindingEnumeration = in.map(b => s"'$b'").mkString(", ") + s" and '$ls'"
+          s"Bindings $bindingEnumeration were removed!"
+      }
+
+      (newContext, Option(message))
+    }
 
 }

--- a/src/main/scala/me/rexim/morganey/interpreter/InterpreterContext.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/InterpreterContext.scala
@@ -8,4 +8,9 @@ case class InterpreterContext(bindings: List[MorganeyBinding], moduleFinder: Mod
     InterpreterContext(binding :: bindings, moduleFinder)
 
   def reset(): InterpreterContext = InterpreterContext(List(), moduleFinder)
+
+  def partitionBindings(f: MorganeyBinding => Boolean): (InterpreterContext, List[MorganeyBinding])= {
+    val (satisfyF, notSatisfyF) = bindings.partition(f)
+    (InterpreterContext(satisfyF, moduleFinder), notSatisfyF)
+  }
 }

--- a/src/test/scala/me/rexim/morganey/interpreter/InterpreterContextSpec.scala
+++ b/src/test/scala/me/rexim/morganey/interpreter/InterpreterContextSpec.scala
@@ -19,4 +19,19 @@ class InterpreterContextSpec extends FlatSpec with Matchers with TestTerms {
     val context = InterpreterContext(bindings, new ModuleFinder(List()))
     context.reset().bindings.isEmpty should be (true)
   }
+
+  it should "partition all known bindings" in {
+    val zero  = MorganeyBinding(m"zero",  m"0")
+    val one   = MorganeyBinding(m"one",   m"1")
+    val two   = MorganeyBinding(m"two",   m"2")
+    val three = MorganeyBinding(m"three", m"3")
+
+    val knownBindings = List(zero, one, two, three)
+    val context = InterpreterContext(knownBindings, new ModuleFinder(List()))
+
+    val (satisfyCtx, notSatisfy) = context.partitionBindings(_.variable.name endsWith "o")
+    val InterpreterContext(satisfy, _) = satisfyCtx
+    satisfy    should be (List(zero, two))
+    notSatisfy should be (List(one, three))
+  }
 }


### PR DESCRIPTION
Instead of just removing a single binding from the context, this implementation allows removing all bindings matching a regex.

Example:

```
\> load prelude
\> :reset [a-z]*t[a-z]* // (bindings containing 't')
Bindings 'true' and 'mult' were removed!
\> <tab>
nil     false   plus    succ
\>
```
## 

closes #149
