### PR TITLE
Fix `x` binding problem during encoding pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,5 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [wiki-lambda-calculus]: https://en.wikipedia.org/wiki/Lambda_calculus
 [scala-sbt]: http://www.scala-sbt.org/
 [execution-semantic]: https://github.com/rexim/Morganey/wiki/Execution-Mode-Semantic
+
+<!-- ForNeVeR ate all of my waffles again -->

--- a/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
@@ -16,10 +16,10 @@ object ChurchPairConverter {
       case _ => None
     }
 
-  def encodePair(p: (LambdaTerm, LambdaTerm), cons: String = "x"): LambdaTerm = {
-    val (car, cdr) = p
-    LambdaFunc(LambdaVar(cons),
-      LambdaApp(LambdaApp(LambdaVar(cons), car), cdr)
+  def encodePair(pair: (LambdaTerm, LambdaTerm)): LambdaTerm = {
+    val (first, second) = pair
+    LambdaFunc(LambdaVar("x"),
+      LambdaApp(LambdaApp(LambdaVar("x"), first), second)
     )
   }
 

--- a/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
@@ -18,9 +18,14 @@ object ChurchPairConverter {
 
   def encodePair(pair: (LambdaTerm, LambdaTerm)): LambdaTerm = {
     val (first, second) = pair
-    LambdaFunc(LambdaVar("x"),
-      LambdaApp(LambdaApp(LambdaVar("x"), first), second)
-    )
+    val x = LambdaVar("x")
+    val y = LambdaVar("y")
+    val z = LambdaVar("z")
+
+    LambdaFunc(z,
+      LambdaApp(LambdaApp(z, x), y))
+      .substitute(x -> first)
+      .substitute(y -> second)
   }
 
   def decodeList(list: LambdaTerm): Option[List[LambdaTerm]] = {

--- a/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
@@ -19,13 +19,20 @@ object ChurchPairConverter {
   def encodePair(pair: (LambdaTerm, LambdaTerm)): LambdaTerm = {
     val (first, second) = pair
     val x = LambdaVar("x")
-    val y = LambdaVar("y")
-    val z = LambdaVar("z")
 
-    LambdaFunc(z,
-      LambdaApp(LambdaApp(z, x), y))
-      .substitute(x -> first)
-      .substitute(y -> second)
+    val pairFunc = {
+      val y = LambdaVar("y")
+      val z = LambdaVar("z")
+
+      LambdaFunc(y,
+        LambdaFunc(z,
+          LambdaApp(LambdaApp(z, x), y)))
+    }
+
+    pairFunc.substitute(x -> first) match {
+      case LambdaFunc(y, body) => body.substitute(y -> second)
+      case _ => throw new IllegalArgumentException("Capture free substitution produced unexpected result")
+    }
   }
 
   def decodeList(list: LambdaTerm): Option[List[LambdaTerm]] = {

--- a/kernel/src/test/scala/me/rexim/morganey/ChurchPairDecodingSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/ChurchPairDecodingSpec.scala
@@ -7,7 +7,7 @@ import me.rexim.morganey.helpers.TestTerms
 import me.rexim.morganey.syntax.LambdaParser
 import org.scalatest._
 
-class ChurchPairConverterSpec extends FlatSpec with Matchers with TestTerms {
+class ChurchPairDecodingSpec extends FlatSpec with Matchers with TestTerms {
   "An identity function" should "be converted to None" in {
     decodePair(I(x)) should be (None)
   }

--- a/kernel/src/test/scala/me/rexim/morganey/ChurchPairEncodingSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/ChurchPairEncodingSpec.scala
@@ -1,0 +1,22 @@
+package me.rexim.morganey
+
+import me.rexim.morganey.ast.LambdaVar
+import me.rexim.morganey.church.ChurchPairConverter
+import me.rexim.morganey.church.ChurchPairConverter._
+import me.rexim.morganey.helpers.TestTerms
+import org.scalatest._
+
+class ChurchPairEncodingSpec extends FlatSpec with Matchers with TestTerms {
+  "Pair of vars `x` and `y`" should "be encoding into a Church pair" in {
+    encodePair((x, y)) should be (pair(x, y, "z"))
+  }
+
+  "Pair of vars `z` and `y`" should "be capture free encoded into a Church pair" in {
+    encodePair((z, y)) should be (pair(z, y, "z##0"))
+  }
+
+  "Pair of vars `z##0` and `z`" should "be capture free encoded into a Church pair" in {
+    val z0 = LambdaVar("z##0")
+    encodePair((z0, z)) should be (pair(z0, z, "z##1"))
+  }
+}

--- a/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
@@ -120,35 +120,35 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
   "Singleton list literals" should "desugar into a single pair" in {
     val res1 = LambdaParser.parseAll(LambdaParser.term, "[0]")
     res1.successful should be (true)
-    res1.get        should be (pair(zero, zero, "x"))
+    res1.get        should be (pair(zero, zero, "z"))
 
     val res2 = LambdaParser.parseAll(LambdaParser.term, "['a']")
     res2.successful should be (true)
-    res2.get        should be (pair(encodeNumber('a'), zero, "x"))
+    res2.get        should be (pair(encodeNumber('a'), zero, "z"))
   }
 
   "Non empty list literals" should "desugar into nested pairs" in {
     val res1 = LambdaParser.parseAll(LambdaParser.term, "[0, 1, 2]")
     res1.successful should be (true)
-    res1.get        should be (pair(zero, pair(one, pair(two, zero, "x"), "x"), "x"))
+    res1.get        should be (pair(zero, pair(one, pair(two, zero, "z"), "z"), "z"))
 
     val res2 = LambdaParser.parseAll(LambdaParser.term, "['a', 'b', 'c']")
     res2.successful should be (true)
-    res2.get        should be (pair(encodeNumber('a'), pair(encodeNumber('b'), pair(encodeNumber('c'), zero, "x"), "x"), "x"))
+    res2.get        should be (pair(encodeNumber('a'), pair(encodeNumber('b'), pair(encodeNumber('c'), zero, "z"), "z"), "z"))
   }
 
   "List literals constructed by ascending ranges, whose bounds are literals" should "desugar into nested pairs" in {
     val res1 = LambdaParser.parseAll(LambdaParser.term, "[0 .. 2]")
     res1.successful should be (true)
-    res1.get        should be (pair(zero, pair(one, pair(two, zero, "x"), "x"), "x"))
+    res1.get        should be (pair(zero, pair(one, pair(two, zero, "z"), "z"), "z"))
 
     val res2 = LambdaParser.parseAll(LambdaParser.term, "[0, 1 .. 2]")
     res2.successful should be (true)
-    res2.get        should be (pair(zero, pair(one, pair(two, zero, "x"), "x"), "x"))
+    res2.get        should be (pair(zero, pair(one, pair(two, zero, "z"), "z"), "z"))
 
     val res3 = LambdaParser.parseAll(LambdaParser.term, "[0, 2 .. 2]")
     res3.successful should be (true)
-    res3.get        should be (pair(zero, pair(two, zero, "x"), "x"))
+    res3.get        should be (pair(zero, pair(two, zero, "z"), "z"))
   }
 
   "List literals constructed by descending ranges, whose bounds are literals" should "desugar into nested pairs" in {
@@ -159,21 +159,21 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
 
     val res2 = LambdaParser.parseAll(LambdaParser.term, "[2, 1 .. 0]")
     res2.successful should be (true)
-    res2.get        should be (pair(two, pair(one, pair(zero, zero, "x"), "x"), "x"))
+    res2.get        should be (pair(two, pair(one, pair(zero, zero, "z"), "z"), "z"))
 
     val res3 = LambdaParser.parseAll(LambdaParser.term, "[2, 0 .. 0]")
     res3.successful should be (true)
-    res3.get        should be (pair(two, pair(zero, zero, "x"), "x"))
+    res3.get        should be (pair(two, pair(zero, zero, "z"), "z"))
   }
 
   "Nested list literals" should "desugar also into nested pairs" in {
     val res = LambdaParser.parseAll(LambdaParser.term, "[[1, 2], 'a', [1, []]]")
-    val fst = pair(one, pair(two, zero, "x"), "x")
+    val fst = pair(one, pair(two, zero, "z"), "z")
     val snd = encodeNumber('a')
     val nil = zero
-    val trd = pair(one, pair(nil, zero, "x"), "x")
+    val trd = pair(one, pair(nil, zero, "z"), "z")
     res.successful should be (true)
-    res.get        should be (pair(fst, pair(snd, pair(trd, zero, "x"), "x"), "x"))
+    res.get        should be (pair(fst, pair(snd, pair(trd, zero, "z"), "z"), "z"))
   }
 
   "List literals constructed by ranges, whose bounds are literals" can "be defined with number-like values" in {
@@ -181,7 +181,7 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
     val b = encodeNumber('b')
     val c = encodeNumber('c')
 
-    val abc = pair(a, pair(b, pair(c, zero, "x"), "x"), "x")
+    val abc = pair(a, pair(b, pair(c, zero, "z"), "z"), "z")
 
     val res1 = LambdaParser.parseAll(LambdaParser.term, "['a' .. 99]")
     res1.successful should be (true)

--- a/kernel/src/test/scala/me/rexim/morganey/helpers/TestTerms.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/helpers/TestTerms.scala
@@ -18,10 +18,10 @@ trait TestTerms {
 
   def I(v : LambdaVar) = LambdaFunc(v, v)
 
-  def pair(first: LambdaTerm, second: LambdaTerm, variable: String = "z") =
-    lfunc(variable,
+  def pair(first: LambdaTerm, second: LambdaTerm, consName: String = "z") =
+    lfunc(consName,
       lapp(
-        lapp(lvar(variable), first),
+        lapp(lvar(consName), first),
         second))
 
   val random = scala.util.Random

--- a/macros/src/test/scala/me/rexim/morganey/meta/InterpolatorSpec.scala
+++ b/macros/src/test/scala/me/rexim/morganey/meta/InterpolatorSpec.scala
@@ -46,7 +46,7 @@ class InterpolatorSpec extends FlatSpec with Matchers with TestTerms {
     m"$nTwo" should be (two)
 
     val numbers = List(0, 1, 2)
-    m"$numbers" should be (pair(zero, pair(one, pair(two, zero, "x"), "x"), "x"))
+    m"$numbers" should be (pair(zero, pair(one, pair(two, zero, "z"), "z"), "z"))
   }
 
   "Lambda terms" should "be converted back to Scala values during unlifting" in {


### PR DESCRIPTION
### Description

Implement pair encoding with capture free substitution.
### Checklist
- [x] Add/Update Unit Tests

---

Close #172 
