### PR TITLE
Return failed computation, if command doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [scala-sbt]: http://www.scala-sbt.org/
 [execution-semantic]: https://github.com/rexim/Morganey/wiki/Execution-Mode-Semantic
 
-<!-- ForNeVeR ate all of my waffles again -->
+<!-- keddelzz and ForNeVeR ate all of my waffles again -->

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [scala-sbt]: http://www.scala-sbt.org/
 [execution-semantic]: https://github.com/rexim/Morganey/wiki/Execution-Mode-Semantic
 
-<!-- keddelzz and ForNeVeR ate all of my waffles again -->
+<!-- keddelzz ate all of my waffles again -->

--- a/src/main/scala/me/rexim/morganey/Commands.scala
+++ b/src/main/scala/me/rexim/morganey/Commands.scala
@@ -1,6 +1,7 @@
 package me.rexim.morganey
 
 import me.rexim.morganey.interpreter.{ReplContext, ReplResult}
+import me.rexim.morganey.reduction.Computation
 import me.rexim.morganey.syntax.LambdaParser
 import me.rexim.morganey.util._
 
@@ -8,18 +9,24 @@ import scala.util.{Failure, Success}
 
 object Commands {
 
-  final type Command = ReplContext => ReplResult[String]
+  final type Command = ReplContext => Computation[ReplResult[String]]
+
+  private def command(f: ReplContext => ReplResult[String]): Command =
+    { context: ReplContext => Computation(f(context)) }
+
+  private def unknownCommand(command: String): Command =
+    { context: ReplContext => Computation.failed(new RuntimeException(s"Unknown command '$command'!")) }
 
   val commandPattern  = ":([a-zA-Z]*)".r
   val commandWithArgs = ":([a-zA-Z]*) (.*)".r
   val unbindCountThreshold = 10
 
   val commands =
-    Map[String, String => Command](
+    Map[String, String => ReplContext => ReplResult[String]](
       "exit"   -> exitREPL,
       "raw"    -> rawPrintTerm,
       "unbind" -> unbindBindings
-    ) withDefault unknownCommand
+    )
 
   def parseCommand(line: String): Option[(String, String)] =
     line match {
@@ -29,12 +36,10 @@ object Commands {
     }
 
   def unapply(line: String): Option[Command] =
-    parseCommand(line).map {
-      case (cmd, args) => commands(cmd)(args.trim)
+    parseCommand(line) map {
+      case (cmd, args) if commands contains cmd => command(commands(cmd)(args.trim))
+      case (cmd, _)                             => unknownCommand(cmd)
     }
-
-  private def unknownCommand(command: String)(args: String)(context: ReplContext): ReplResult[String] =
-    ReplResult(context, Some(s"Unknown command '$command'!"))
 
   private def exitREPL(args: String)(context: ReplContext): ReplResult[String] =
     sys.exit(0)

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyRepl.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyRepl.scala
@@ -16,7 +16,7 @@ object MorganeyRepl {
   def evalLine(context: ReplContext, line: String): Computation[ReplResult[String]] =
     line.trim match {
       case ""            => Computation(ReplResult(context))
-      case Commands(cmd) => Computation(cmd(context))
+      case Commands(cmd) => cmd(context)
       case input         => parseAndEval(context, line)
     }
 


### PR DESCRIPTION
closes #207
## 

It would be a much more elegant solution if failures are not expressed by `Computation.failed`, but with `ReplResult.failed`. We might want to do that in the future.
