### PR TITLE
Fix morganey execution hangging problem

### DIFF
--- a/docs/samples/fib.mgn
+++ b/docs/samples/fib.mgn
@@ -1,4 +1,3 @@
 load prelude
 
-main := pair 0 (Y (\fib.n.a.b. iszero n 0 (pair a (fib (pred n) b (plus a b)))) 15 0 1)
-
+main := Y (\fib.n.a.b. (iszero n) 0 (pair a (fib (pred n) b (plus a b)))) 15 0 1

--- a/docs/samples/succ-stdin.mgn
+++ b/docs/samples/succ-stdin.mgn
@@ -1,3 +1,3 @@
 load prelude
 
-main := Y (\map.xs. (isnil xs) 0 (pair (succ (first xs)) (map (second xs))))
+main := Y (\map.xs. (isnil xs) 0 (pair (succ (first xs)) (map (second xs)))) input

--- a/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
@@ -130,7 +130,7 @@ case class LambdaApp(leftTerm: LambdaTerm, rightTerm: LambdaTerm) extends Lambda
   }
 }
 
-case class LambdaInput(input: Stream[Char]) extends LambdaTerm {
+case class LambdaInput(input: () => Stream[Char]) extends LambdaTerm {
   override val freeVars: Set[String] = Set()
 
   override def substitute(substitution: (LambdaVar, LambdaTerm)): LambdaTerm =
@@ -141,8 +141,8 @@ case class LambdaInput(input: Stream[Char]) extends LambdaTerm {
     * put at the begining of the virtual input list
     */
   def forceNextChar(): LambdaTerm =
-    input match {
-      case x #:: xs => encodePair((encodeNumber(x.toInt), LambdaInput(xs)))
+    input() match {
+      case x #:: xs => encodePair((encodeNumber(x.toInt), LambdaInput(() => xs)))
       case _ => encodeList(List())
     }
 

--- a/kernel/src/test/scala/me/rexim/morganey/TermRenderSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/TermRenderSpec.scala
@@ -67,8 +67,8 @@ class TermRenderSpec extends FlatSpec with Matchers with TestTerms {
 
 
   "A lazy sequence of characters" should "be rendered to \"<input>\"" in {
-    LambdaInput(Stream.empty[Char]).toString should be ("<input>")
-    LambdaInput("foo bar".toStream).toString should be ("<input>")
+    LambdaInput(() => Stream.empty[Char]).toString should be ("<input>")
+    LambdaInput(() => "foo bar".toStream).toString should be ("<input>")
   }
 
   "Parsing a term, and reparsing the result of the pretty-printer" should "always succeed" in {

--- a/src/main/scala/me/rexim/morganey/Main.scala
+++ b/src/main/scala/me/rexim/morganey/Main.scala
@@ -75,7 +75,7 @@ object Main extends SignalHandler {
     import me.rexim.morganey.reduction.NormalOrder._
 
     val result = loadModuleFromReader(new java.io.FileReader(programFile), context.moduleFinder, Set())
-      .flatMap(compileProgram(Source.stdin.toStream))
+      .flatMap(compileProgram(() => Source.stdin.toStream))
       .map(_.norReduce())
 
     result match {

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyExecutor.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyExecutor.scala
@@ -43,10 +43,10 @@ object MorganeyExecutor {
     }
   }
 
-  def compileProgram(input: Stream[Char])(rawProgram: List[MorganeyBinding]): Try[LambdaTerm] = {
+  def compileProgram(input: () => Stream[Char])(rawProgram: List[MorganeyBinding]): Try[LambdaTerm] = {
     rawProgram.partition(_.variable.name == "main") match {
       case (List(MorganeyBinding(LambdaVar("main"), program)), bindings) =>
-        LambdaApp(program, LambdaInput(input)).addBindings(bindings) match {
+        program.addBindings(MorganeyBinding(LambdaVar("input"), LambdaInput(input)) :: bindings) match {
           case Right(compiledProgram) => Success(compiledProgram)
 
           case Left(NonExistingBinding(name)) =>

--- a/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
+++ b/src/test/scala/me/rexim/morganey/LambdaInputSpecs.scala
@@ -8,9 +8,9 @@ import me.rexim.morganey.helpers.TestTerms
 import org.scalatest._
 
 class LambdaInputSpecs extends FlatSpec with Matchers with TestTerms {
-  val longInput = LambdaInput("khooy".toStream)
-  val singleCharInput = LambdaInput("k".toStream)
-  val emptyInput = LambdaInput(Stream.empty)
+  val longInput = LambdaInput(() => "khooy".toStream)
+  val singleCharInput = LambdaInput(() => "k".toStream)
+  val emptyInput = LambdaInput(() => Stream.empty)
 
   "Lambda input" should "have zero free vars by definition" in {
     longInput.freeVars.isEmpty should be (true)

--- a/src/test/scala/me/rexim/morganey/interpreter/MorganeyExecutorSpecs.scala
+++ b/src/test/scala/me/rexim/morganey/interpreter/MorganeyExecutorSpecs.scala
@@ -28,7 +28,7 @@ class MorganeyExecutorSpecs extends FlatSpec with Matchers {
   val programInput = "khooy".toStream
 
   "Executor" should "compile a correct program to a reducible term" in {
-    val Right(expectedProgram) = lapp(programBody, LambdaInput(() => programInput)).addBindings(programBindings)
+    val Right(expectedProgram) = programBody.addBindings(MorganeyBinding(LambdaVar("input"), LambdaInput(() => programInput)) :: programBindings)
     MorganeyExecutor.compileProgram(() => programInput)(rawProgram) should be (Success(expectedProgram))
   }
 

--- a/src/test/scala/me/rexim/morganey/interpreter/MorganeyExecutorSpecs.scala
+++ b/src/test/scala/me/rexim/morganey/interpreter/MorganeyExecutorSpecs.scala
@@ -28,12 +28,12 @@ class MorganeyExecutorSpecs extends FlatSpec with Matchers {
   val programInput = "khooy".toStream
 
   "Executor" should "compile a correct program to a reducible term" in {
-    val Right(expectedProgram) = lapp(programBody, LambdaInput(programInput)).addBindings(programBindings)
-    MorganeyExecutor.compileProgram(programInput)(rawProgram) should be (Success(expectedProgram))
+    val Right(expectedProgram) = lapp(programBody, LambdaInput(() => programInput)).addBindings(programBindings)
+    MorganeyExecutor.compileProgram(() => programInput)(rawProgram) should be (Success(expectedProgram))
   }
 
   "Executor" should "fail an incorrect program" in {
-    MorganeyExecutor.compileProgram(programInput)(programBindings).isFailure should be (true)
+    MorganeyExecutor.compileProgram(() =>programInput)(programBindings).isFailure should be (true)
   }
 
   "Executor" should "not interpret empty loading nodes and just ignore them" in {

--- a/src/test/scala/me/rexim/morganey/reduction/CallByNameSpec.scala
+++ b/src/test/scala/me/rexim/morganey/reduction/CallByNameSpec.scala
@@ -51,6 +51,6 @@ class CallByNameSpec extends FlatSpec with Matchers with TestTerms {
 
   "Input term" should "be evaluated once by the strategy" in {
     val input = "abc"
-    decodePair(LambdaInput(input.toStream).cbnReduce()) should be (Some((encodeNumber('a'.toInt), LambdaInput(input.tail.toStream))))
+    decodePair(LambdaInput(() => input.toStream).cbnReduce()) should be (Some((encodeNumber('a'.toInt), LambdaInput(() => input.tail.toStream))))
   }
 }

--- a/src/test/scala/me/rexim/morganey/reduction/CallByNameSpec.scala
+++ b/src/test/scala/me/rexim/morganey/reduction/CallByNameSpec.scala
@@ -50,7 +50,15 @@ class CallByNameSpec extends FlatSpec with Matchers with TestTerms {
   }
 
   "Input term" should "be evaluated once by the strategy" in {
-    val input = "abc"
-    decodePair(LambdaInput(() => input.toStream).cbnReduce()) should be (Some((encodeNumber('a'.toInt), LambdaInput(() => input.tail.toStream))))
+    val inputData = "abc"
+    val originalInput = () => inputData.toStream
+
+    decodePair(LambdaInput(originalInput).cbnReduce()) match {
+      case Some((hd, LambdaInput(inputTail))) =>
+        hd should be (encodeNumber('a'.toInt))
+        inputTail() should be (originalInput().tail)
+
+      case result => fail(s"Input term was not evaluated properly")
+    }
   }
 }

--- a/src/test/scala/me/rexim/morganey/reduction/NormalOrderSpec.scala
+++ b/src/test/scala/me/rexim/morganey/reduction/NormalOrderSpec.scala
@@ -40,6 +40,6 @@ class NormalOrderSpec extends FlatSpec with Matchers with TestTerms {
 
   "Input term" should "full evaluated by the strategy" in {
     val input = "abc"
-    decodeString(new LambdaInput(input.toStream).norReduce()) should be (Some(input))
+    decodeString(new LambdaInput(() => input.toStream).norReduce()) should be (Some(input))
   }
 }


### PR DESCRIPTION
<!-- NOTICE: this template serves as a recommendation, not as a requirement. -->
### Description
- Pass input by name to LambdaInput
- Make input a separate binding tha main binding depends on
- Fix samples according to the new semantic
### Checklist
- [x] Update docs ([diff](https://github.com/morganey-lang/Morganey/wiki/Execution-Mode-Semantic/_compare/5ba0078381d91cf0e4cb05b64ed679db8650dbcf...d42898e44b8810985a88796b7f08bf047a72b7b5))
- [x] Add/Update Unit Tests

---

Close #215 
