### PR TITLE
Extend parser to support non-literal ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After that find the uberjar at `target/scala-2.11/morganey-assembly-<version>.ja
                           | '\\[\\'"bfnrt]'
     <string-literal> ::= <java-string-literal>
     <list-literal> ::= "[" [ term { "," term } ] "]"
-                     | "[" <number-or-character> [ "," <number-or-character> ] ".." <number-or-character> "]"
+                     | "[" <term> [ "," <term> ] ".." <term> "]"
     <number-or-character> ::= <numeric-literal>
                             | <character-literal>
 

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/LambdaParser.scala
@@ -52,10 +52,14 @@ class LambdaParser extends JavaTokenParsers with ImplicitConversions {
       ChurchPairConverter.encodeString(unquoteString(s))
     }
 
+  private def rangeParser[T](q: => Parser[T]): Parser[T ~ Option[T] ~ T] = {
+    val p = q
+    p ~ opt(comma ~> p) ~ (rangeOperator ~> p)
+  }
+
   private def rangeConstant: Parser[LambdaTerm] = {
     val number = validNumberLiteral | validCharacterLiteral ^^ (_.toInt)
-    val parser = number ~ opt(comma ~> number) ~ (rangeOperator ~> number)
-    parser ^^ { case start ~ next ~ exit =>
+    rangeParser(number) ^^ { case start ~ next ~ exit =>
       val step  = next.map(_ - start).getOrElse(1)
       val range = NumericRange.inclusive(start, exit, step).toList
       val nums  = range map ChurchNumberConverter.encodeNumber
@@ -66,6 +70,16 @@ class LambdaParser extends JavaTokenParsers with ImplicitConversions {
   def listLiteral: Parser[LambdaTerm] = (
       brackets(repsep(term, comma)) ^^ ChurchPairConverter.encodeList
     | brackets(rangeConstant)
+    | brackets {
+        rangeParser(term) ^^ { case start ~ next ~ exit =>
+          val range         = LambdaVar("range")
+          val rangeWithNext = LambdaVar("rangeWithNext")
+          next match {
+            case None      => LambdaApp(LambdaApp(range, start), exit)
+            case Some(nxt) => LambdaApp(LambdaApp(LambdaApp(rangeWithNext, start), nxt), exit)
+          }
+        }
+      }
   )
 
   /* ============================== Core lambda terms =============================== */


### PR DESCRIPTION
After manually importing `prelude` the parser now is able to create ranges constructed from non-literal terms.

```
\> load prelude
\> [ id 1 .. id 10 ]
numbers: [1,2,3,4,5,6,7,8,9,10]
\> [ id 1, id 3 .. id 10 ]
numbers: [1,3,5,7,9]
```

After implementing #79 the manual import should not be necessary anymore.
## 

closes #201
