### PR TITLE
#234: fix console redirection issues on Windows

### DIFF
--- a/src/main/scala/me/rexim/morganey/Main.scala
+++ b/src/main/scala/me/rexim/morganey/Main.scala
@@ -50,8 +50,7 @@ object Main extends SignalHandler {
 
     val running = true
     var globalContext = context
-    val con = new ConsoleReader()
-    con.setPrompt("λ> ")
+    val con = initializeConsoleReader()
     con.addCompleter(new TerminalReplAutocompletion(() => globalContext))
 
     def line() = Option(con.readLine()).map(_.trim)
@@ -92,5 +91,22 @@ object Main extends SignalHandler {
       case Nil => startRepl(context)
       case programFile :: _ => executeProgram(context, programFile)
     }
+  }
+
+  private def initializeConsoleReader(): ConsoleReader = {
+    lazy val isInputRedirected = System.console == null
+    lazy val isWindows =
+      Option(System.getProperty("os.name"))
+        .exists(_.toLowerCase.contains("windows"))
+
+    if (isWindows && isInputRedirected) {
+      // Need to disable native console usage in Windows with redirected
+      // input, otherwise JLine just hangs when trying to read it.
+      System.setProperty("jline.WindowsTerminal.directConsole", "false")
+    }
+
+    val con = new ConsoleReader()
+    con.setPrompt("λ> ")
+    con
   }
 }


### PR DESCRIPTION
### Description

Fixes #234; fixes #214. The core problem lies in the JLine implementation. While debugging the issue, I found that [this line](https://github.com/jline/jline2/blob/72641325da0d15efd2555d377800d20840bad7d6/src/main/java/jline/WindowsTerminal.java#L164) was constantly throwing and swalloging `ReadConsoleInputW` exceptions. `ReadConsoleInputW` is a Windows API function, and its binding is defined somewhere in [jansi-native](https://github.com/fusesource/jansi-native) that's used by JLine. This function (and Windows Console API in general) cannot be called if the process' input or output is redirected (i.e. it have no its own console window to write to or to read from).

So, JLine tries to call the function and it cannot. That's the reason it hangs completely. So, I've decided to implement simple detection of case "we're running on Windows and our input is redirected". I've copied the Windows detection from jline [`WindowsTerminal.java`](https://github.com/jline/jline2/blob/f9b8398fa92b7de099ab9dd27b83b86239cc0516/src/main/java/jline/TerminalFactory.java#L97-L98), and I detect whether input is redirected by checking if `System.console()` exists. I believe these heuristics are decent enough to do the right thing™.
### Checklist
- [ ] ~~Update docs~~ — not necessary
- [ ] ~~Add/Update Unit Tests~~ — will be updated in scope of #231 
