### PR TITLE
Add version to the fatjar name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ lazy val commonSettings = Seq(
   ),
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   test in assembly := {},
-  assemblyJarName := "morganey.jar"
+  buildInfoKeys := Seq[BuildInfoKey](version),
+  buildInfoPackage := "me.rexim.morganey"
 )
 
 lazy val macroSettings = Seq(
@@ -66,6 +67,7 @@ addCommandAlias("retest", ";rebuild;test")
  */
 
 lazy val morganey = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
   .settings(commonSettings :_*)
   .settings(
     mainClass := Some("me.rexim.morganey.Main"),
@@ -97,6 +99,7 @@ lazy val stdlib = (project in file("std"))
   .settings(stdlibSettings :_*)
 
 lazy val funtests = (project in file("funtests"))
+  .enablePlugins(BuildInfoPlugin)
   .settings(commonSettings :_*)
   .settings(funtestsSettings :_*)
   .dependsOn(hiddenArgs)

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ build := {
 
   IO.copyFile(macroFile, targetDir / macroFile.getName())
   IO.copyFile(kernelFile, targetDir / kernelFile.getName())
-  IO.copyFile(stdlibFile, targetDir / stdlibFile.getName())  
+  IO.copyFile(stdlibFile, targetDir / stdlibFile.getName())
 }
 
 addCommandAlias("funtests", ";assembly;funtests/test")

--- a/funtests/src/test/scala/me/rexim/morganey/funtests/MorganeyProcess.scala
+++ b/funtests/src/test/scala/me/rexim/morganey/funtests/MorganeyProcess.scala
@@ -1,8 +1,9 @@
 package me.rexim.morganey.funtests
 
 import scala.sys.process._
+import me.rexim.morganey.BuildInfo
 
 trait MorganeyProcess {
   def morganey(args: String*): ProcessBuilder =
-    s"java -jar ./target/scala-2.11/morganey.jar ${args.mkString(" ")}"
+    s"java -jar ./target/scala-2.11/morganey-assembly-${BuildInfo.version}.jar ${args.mkString(" ")}"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ logLevel := Level.Warn
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
<!-- NOTICE: this template serves as a recommendation, not as a requirement. -->
### Description

Add version to the fatjar name and use sbt-buildinfo plugin for constructing correct path to the fatjar in the funtests.
### Checklist
- [x] ~~Update docs~~
- [x] Add/Update Unit Tests

---

Close #240
