### PR TITLE
Implement classpath support for ModuleFinder

### DIFF
--- a/src/main/scala/me/rexim/morganey/ReplAutocompletion.scala
+++ b/src/main/scala/me/rexim/morganey/ReplAutocompletion.scala
@@ -14,6 +14,8 @@ import scala.util.Try
 
 object ReplAutocompletion {
 
+  // TODO: use classpath modules in ReplAutocompletion
+
   def complete(buffer: String, context: ReplContext): List[String] =
     complete(buffer, buffer.length, context)
 

--- a/src/main/scala/me/rexim/morganey/ReplAutocompletion.scala
+++ b/src/main/scala/me/rexim/morganey/ReplAutocompletion.scala
@@ -56,7 +56,7 @@ object ReplAutocompletion {
     def findAllModulesIn(path: String): List[(File, File)] =
       Try(
         moduleFinder.paths.toStream
-          .map { f => (f, new File(f, loadPathToRelativeFile(path))) }
+          .map { f => (f, new File(f, modulePathToRelativeFile(path))) }
           .filter { case (_, f) => f.exists() }
           .flatMap { case (root, f) => f.listFiles() map (root -> _) }
           .filter { case (_, f) => validMorganeyElement(f) }

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyExecutor.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyExecutor.scala
@@ -11,6 +11,8 @@ import me.rexim.morganey.ast.error.{BindingLoop, NonExistingBinding}
 
 object MorganeyExecutor {
 
+  // TODO: use classpath modules in MorganeyExecutor
+
   def interpretNode(node: MorganeyNode,
                     moduleFinder: ModuleFinder,
                     loadedModules: Set[String]): Try[List[MorganeyBinding]] =

--- a/src/main/scala/me/rexim/morganey/module/ModuleFinder.scala
+++ b/src/main/scala/me/rexim/morganey/module/ModuleFinder.scala
@@ -1,13 +1,14 @@
 package me.rexim.morganey.module
 
 import java.io.File
+import java.net.URL
 
 import ModuleFinder._
 
 object ModuleFinder {
   val fileExtension = "mgn"
 
-  def loadPathToRelativeFile(modulePath: String): String =
+  def modulePathToRelativeFile(modulePath: String): String =
     modulePath.replace('.', File.separatorChar)
 
   def relativeFileToLoadPath(relativeFile: String): String =
@@ -20,7 +21,13 @@ object ModuleFinder {
 class ModuleFinder(val paths: List[File]) {
   def findModuleFile(modulePath: String): Option[File] = {
     paths.toStream
-      .map(new File(_, s"${loadPathToRelativeFile(modulePath)}.$fileExtension"))
+      .map(new File(_, s"${modulePathToRelativeFile(modulePath)}.$fileExtension"))
       .find(_.isFile())
+  }
+
+  def findModuleInClasspath(classLoader: ClassLoader, modulePath: String): Option[URL] = {
+    val resourcePath = modulePathToRelativeFile(modulePath)
+    val resourceUrl = classLoader.getResource(resourcePath)
+    Option(resourceUrl)
   }
 }

--- a/src/test/scala/me/rexim/morganey/module/ModuleFinderSpec.scala
+++ b/src/test/scala/me/rexim/morganey/module/ModuleFinderSpec.scala
@@ -18,4 +18,6 @@ class ModuleFinderSpec extends FlatSpec with Matchers {
   "Module finder" should "not find unexisting modules" in {
     moduleFinder.findModuleFile("khooy") should be (None)
   }
+
+  // TODO: add specs for ModuleFinder.findModuleInClasspath
 }


### PR DESCRIPTION
### Remaining work
- Use classpath modules in ReplAutocompletion
- Use classpath modules in MorganeyExecutor
- Add specs for ModuleFinder.findModuleInClasspath

Split #222 
