### PR TITLE
Refactor morganey util package

### DIFF
--- a/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/ast/LambdaTerm.scala
@@ -3,7 +3,7 @@ package me.rexim.morganey.ast
 import me.rexim.morganey.ast.error._
 import me.rexim.morganey.church.ChurchNumberConverter._
 import me.rexim.morganey.church.ChurchPairConverter._
-import me.rexim.morganey.util._
+import me.rexim.morganey.monad._
 import hiddenargs._
 
 import scala.annotation.tailrec

--- a/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/church/ChurchPairConverter.scala
@@ -1,10 +1,9 @@
 package me.rexim.morganey.church
 
-import me.rexim.morganey.ast.{LambdaApp, LambdaFunc, LambdaVar, LambdaTerm}
-import me.rexim.morganey.ast.LambdaTerm
-import me.rexim.morganey.church.ChurchNumberConverter.{decodeNumber, encodeNumber}
-import me.rexim.morganey.util._
 import hiddenargs._
+import me.rexim.morganey.ast.{LambdaApp, LambdaFunc, LambdaTerm, LambdaVar}
+import me.rexim.morganey.church.ChurchNumberConverter.{decodeNumber, encodeNumber}
+import me.rexim.morganey.monad._
 
 object ChurchPairConverter {
   // (λ z . ((z x) y))

--- a/kernel/src/main/scala/me/rexim/morganey/monad/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/monad/package.scala
@@ -1,0 +1,24 @@
+package me.rexim.morganey
+
+import scala.util.Try
+
+package object monad {
+  /**
+    * Returns 'None', if one of the Options in 'lst' is 'None',
+    * otherwise the elements are collected in a 'Some'.
+    */
+  def sequence[T](lst: List[Option[T]]): Option[List[T]] =
+  lst.foldRight(Option(List.empty[T])) {
+    case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
+  }
+
+  def sequence[T](lst: List[Try[T]]): Try[List[T]] =
+    lst.foldRight(Try(List.empty[T])) {
+      case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
+    }
+
+  def sequenceRight[L, R](lst: List[Either[L, R]]): Either[L, List[R]] =
+    lst.foldRight[Either[L, List[R]]](Right(List.empty[R])) {
+      case (ele, acc) => acc.right.flatMap(lst => ele.right.map(_ :: lst))
+    }
+}

--- a/kernel/src/main/scala/me/rexim/morganey/monad/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/monad/package.scala
@@ -8,9 +8,9 @@ package object monad {
     * otherwise the elements are collected in a 'Some'.
     */
   def sequence[T](lst: List[Option[T]]): Option[List[T]] =
-  lst.foldRight(Option(List.empty[T])) {
-    case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
-  }
+    lst.foldRight(Option(List.empty[T])) {
+      case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
+    }
 
   def sequence[T](lst: List[Try[T]]): Try[List[T]] =
     lst.foldRight(Try(List.empty[T])) {

--- a/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/syntax/Language.scala
@@ -1,5 +1,9 @@
 package me.rexim.morganey.syntax
 
+import hiddenargs.{hidden, hiddenargs}
+
+import scala.annotation.tailrec
+
 object Language {
 
   val identifier         = "[a-zA-Z][a-zA-Z0-9]*"
@@ -49,4 +53,21 @@ object Language {
 
   val rangeOperator      = ".."
 
+  @hiddenargs
+  @tailrec
+  def unquoteString(s: String, @hidden acc: String = ""): String =
+    if (s.isEmpty) acc else s(0) match {
+      case '"' => unquoteString(s.tail, acc)
+      case '\\' => s(1) match {
+        case 'b' => unquoteString(s.drop(2), acc + "\b")
+        case 'f' => unquoteString(s.drop(2), acc + "\f")
+        case 'n' => unquoteString(s.drop(2), acc + "\n")
+        case 'r' => unquoteString(s.drop(2), acc + "\r")
+        case 't' => unquoteString(s.drop(2), acc + "\t")
+        case '"' => unquoteString(s.drop(2), acc + "\"")
+        case 'u' => unquoteString(s.drop(6), acc + Integer.parseInt(s.slice(2, 6), 16).toChar.toString)
+        case c   => unquoteString(s.drop(2), acc + c.toString)
+      }
+      case c => unquoteString(s.tail, acc + c.toString)
+    }
 }

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -1,15 +1,13 @@
 package me.rexim.morganey
 
 import java.io.{File, FileInputStream, InputStreamReader, Reader}
+import java.net.URL
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.regex.Pattern
-import java.net.URL
+
+import me.rexim.morganey.syntax.{LambdaParser, LambdaParserException}
 
 import scala.util._
-import me.rexim.morganey.syntax.{LambdaParser, LambdaParserException}
-import hiddenargs._
-
-import scala.annotation.tailrec
 
 package object util {
 
@@ -19,23 +17,6 @@ package object util {
       s: String => pattern.matcher(s).matches()
     }.toOption
 
-  @hiddenargs
-  @tailrec
-  def unquoteString(s: String, @hidden acc: String = ""): String =
-    if (s.isEmpty) acc else s(0) match {
-      case '"' => unquoteString(s.tail, acc)
-      case '\\' => s(1) match {
-        case 'b' => unquoteString(s.drop(2), acc + "\b")
-        case 'f' => unquoteString(s.drop(2), acc + "\f")
-        case 'n' => unquoteString(s.drop(2), acc + "\n")
-        case 'r' => unquoteString(s.drop(2), acc + "\r")
-        case 't' => unquoteString(s.drop(2), acc + "\t")
-        case '"' => unquoteString(s.drop(2), acc + "\"")
-        case 'u' => unquoteString(s.drop(6), acc + Integer.parseInt(s.slice(2, 6), 16).toChar.toString)
-        case c   => unquoteString(s.drop(2), acc + c.toString)
-      }
-      case c => unquoteString(s.tail, acc + c.toString)
-    }
 
   def reader(path: String): Try[Reader] = reader(new File(path))
 

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -52,6 +52,7 @@ package object util {
   implicit class ParserOps[T <: LambdaParser](parser: T) {
     def parseWith[R](input: InputSource, f: T => parser.Parser[R]): Try[R] = {
       val production = f(parser)
+      // TODO(#279): Move logic inside of ParseOps.parseWith to InputSource
       val result = input match {
         case StringSource(string) => parser.parseAll(production, string)
         case ReaderSource(reader) => parser.parseAll(production, reader)

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -48,6 +48,7 @@ package object util {
       result
     }
 
+  // TODO(#278): Move ParseOps and InputSource closer to LambdaParser
   implicit class ParserOps[T <: LambdaParser](parser: T) {
     def parseWith[R](input: InputSource, f: T => parser.Parser[R]): Try[R] = {
       val production = f(parser)

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -11,6 +11,7 @@ import scala.util._
 
 package object util {
 
+  // TODO(#276): move validRegex to Commands
   def validRegex(regex: String): Option[String => Boolean] =
     Try {
       val pattern = Pattern.compile(regex)

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -19,6 +19,7 @@ package object util {
     }.toOption
 
 
+  // TODO(#277): move reader stuff to me.rexim.morganey.reader
   def reader(path: String): Try[Reader] = reader(new File(path))
 
   def reader(file: File): Try[Reader] = {

--- a/kernel/src/main/scala/me/rexim/morganey/util/package.scala
+++ b/kernel/src/main/scala/me/rexim/morganey/util/package.scala
@@ -13,25 +13,6 @@ import scala.annotation.tailrec
 
 package object util {
 
-  /**
-   * Returns 'None', if one of the Options in 'lst' is 'None',
-   * otherwise the elements are collected in a 'Some'.
-   */
-  def sequence[T](lst: List[Option[T]]): Option[List[T]] =
-    lst.foldRight(Option(List.empty[T])) {
-      case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
-    }
-
-  def sequence[T](lst: List[Try[T]]): Try[List[T]] =
-    lst.foldRight(Try(List.empty[T])) {
-      case (ele, acc) => acc.flatMap(lst => ele.map(_ :: lst))
-    }
-
-  def sequenceRight[L, R](lst: List[Either[L, R]]): Either[L, List[R]] =
-    lst.foldRight[Either[L, List[R]]](Right(List.empty[R])) {
-      case (ele, acc) => acc.right.flatMap(lst => ele.right.map(_ :: lst))
-    }
-
   def validRegex(regex: String): Option[String => Boolean] =
     Try {
       val pattern = Pattern.compile(regex)

--- a/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/ParserSpec.scala
@@ -257,4 +257,19 @@ class ParserSpec extends FlatSpec with Matchers with TestTerms {
     func.get        should be (lnested(List("a", "b", "c", "d"), body))
   }
 
+  "The unquoteString function" should "remove escape sequences parsed from the parser" in {
+    Language.unquoteString("")        should be ("")
+    Language.unquoteString(" ")       should be (" ")
+    Language.unquoteString("test")    should be ("test")
+    Language.unquoteString("\\b")     should be ("\b")
+    Language.unquoteString("\\f")     should be ("\f")
+    Language.unquoteString("\\n")     should be ("\n")
+    Language.unquoteString("\\r")     should be ("\r")
+    Language.unquoteString("\\t")     should be ("\t")
+    Language.unquoteString("\\\"")    should be ("\"")
+    Language.unquoteString("\\u0020") should be ("\u0020")
+    Language.unquoteString("\\\\")    should be ("\\")
+
+    Language.unquoteString("\\\"Hello, World!\\n\\\"") should be ("\"Hello, World!\n\"")
+  }
 }

--- a/kernel/src/test/scala/me/rexim/morganey/util/UtilSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/util/UtilSpec.scala
@@ -26,20 +26,5 @@ class UtilSpec extends FlatSpec with Matchers {
     matcher2                      should be (None)
   }
 
-  "The unquoteString function" should "remove escape sequences parsed from the parser" in {
-    unquoteString("")        should be ("")
-    unquoteString(" ")       should be (" ")
-    unquoteString("test")    should be ("test")
-    unquoteString("\\b")     should be ("\b")
-    unquoteString("\\f")     should be ("\f")
-    unquoteString("\\n")     should be ("\n")
-    unquoteString("\\r")     should be ("\r")
-    unquoteString("\\t")     should be ("\t")
-    unquoteString("\\\"")    should be ("\"")
-    unquoteString("\\u0020") should be ("\u0020")
-    unquoteString("\\\\")    should be ("\\")
-
-    unquoteString("\\\"Hello, World!\\n\\\"") should be ("\"Hello, World!\n\"")
-  }
 
 }

--- a/kernel/src/test/scala/me/rexim/morganey/util/UtilSpec.scala
+++ b/kernel/src/test/scala/me/rexim/morganey/util/UtilSpec.scala
@@ -1,6 +1,6 @@
 package me.rexim.morganey.util
 
-import me.rexim.morganey.util._
+import me.rexim.morganey.monad._
 import org.scalatest._
 
 class UtilSpec extends FlatSpec with Matchers {

--- a/macros/src/main/scala/me/rexim/morganey/meta/Unliftable.scala
+++ b/macros/src/main/scala/me/rexim/morganey/meta/Unliftable.scala
@@ -3,7 +3,7 @@ package me.rexim.morganey.meta
 import me.rexim.morganey.ast.LambdaTerm
 import me.rexim.morganey.church.ChurchNumberConverter.{decodeNumber, decodeChar}
 import me.rexim.morganey.church.ChurchPairConverter.{decodeList, decodePair}
-import me.rexim.morganey.util.sequence
+import me.rexim.morganey.monad.sequence
 
 import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds

--- a/src/main/scala/me/rexim/morganey/interpreter/MorganeyCompiler.scala
+++ b/src/main/scala/me/rexim/morganey/interpreter/MorganeyCompiler.scala
@@ -4,6 +4,7 @@ import scala.util._
 import me.rexim.morganey.ast._
 import me.rexim.morganey.syntax.{LambdaParser, LambdaParserException}
 import me.rexim.morganey.module._
+import me.rexim.morganey.monad._
 import me.rexim.morganey.util._
 import java.io.Reader
 


### PR DESCRIPTION
### Done
- Move `sequence` stuff to `me.rexim.morganey.monad`
- Move `unquoteString` to `LambdaParser`
### Remaining Work
- Move `validRegex` to `Commands`
- Move `reader` stuff to `me.rexim.morganey.reader`
- Move `ParseOps` and `InputSource` closer to `LambdaParser`
- Move logic inside of `ParseOps.parseWith` to `InputSource`
### Checklist
- [X] ~~Update docs~~
- [X] Add/Update Unit Tests

---

Splits #266 
