### PR TITLE
Fix yet another file path separator problem on Windows

### DIFF
--- a/src/main/scala/me/rexim/morganey/module/ModuleFinder.scala
+++ b/src/main/scala/me/rexim/morganey/module/ModuleFinder.scala
@@ -11,6 +11,9 @@ object ModuleFinder {
   def modulePathToRelativeFile(modulePath: String): String =
     modulePath.replace('.', File.separatorChar)
 
+  def modulePathToRelativeURL(modulePath: String): String =
+    modulePath.replace('.', '/')
+
   def relativeFileToLoadPath(relativeFile: String): String =
     relativeFile.replace(File.separatorChar, '.')
 
@@ -27,7 +30,7 @@ class ModuleFinder(val paths: List[File]) {
 
   def findModuleInClasspath(modulePath: String): Option[URL] = {
     val classLoader = this.getClass.getClassLoader
-    val resourcePath = s"${modulePathToRelativeFile(modulePath)}.$fileExtension"
+    val resourcePath = s"${modulePathToRelativeURL(modulePath)}.$fileExtension"
     val resourceUrl = classLoader.getResource(resourcePath)
     Option(resourceUrl)
   }

--- a/std/src/main/resources/std/math/arithmetic.mgn
+++ b/std/src/main/resources/std/math/arithmetic.mgn
@@ -14,4 +14,4 @@ minus := \m.n. n pred m
 
 mult := \m.n.f. m (n f)
 
-iszero := λn.n (λx.a.b.b) (\a.b.a)
+iszero := \n.n (\x.a.b.b) (\a.b.a)


### PR DESCRIPTION
ModuleFinder is kinda in an intermediate state of migration from file-based approach to the classpath-based one: https://github.com/morganey-lang/Morganey/issues/222#issuecomment-252682563

For file-based one, we have to use `File.separatorChar` as the file path separator. For the classpath-based one, we have to use `/`, since classpath-based approach works only with URLs.

After resolving #257 everyting related to the file-based approach must be eliminated.

Close #280 
