### PR TITLE
Added turing machine example

### DIFF
--- a/docs/samples/turing-machine.mgn
+++ b/docs/samples/turing-machine.mgn
@@ -110,18 +110,17 @@ def getTape := \machine.head machine
 /** returns the element at the n-th position */
 def getN := Y (\rec.index.list. (gt index 0) (rec (minus index 1) (tail list)) (head list))
 
-/**
- * Example usage:
- *
- * def tape := []
- * def program := [
- *   [1, 0, 1, 1, 2],
- *   [1, 2, 'x', 1, 0],
- *   [2, 0, 2, 1, 3],
- *   [3, 0, 1, 0, 1]
- * ]
- * def head := 0
- * def start := 1
- * def machine := newMachine tape head start program
- * def main := runMachine machine 
- */
+/** Example usage: */
+/*
+def tape := []
+def program := [
+  [1, 0, 1, 1, 2],
+  [1, 2, 'x', 1, 0],
+  [2, 0, 2, 1, 3],
+  [3, 0, 1, 0, 1]
+]
+def head := 0
+def start := 1
+def machine := newMachine tape head start program
+def main := runMachine machine
+*/

--- a/docs/samples/turing-machine.mgn
+++ b/docs/samples/turing-machine.mgn
@@ -1,0 +1,127 @@
+load std.prelude
+
+/**
+ * Format of the Turing Machine:
+ * [tape, head, state, program]
+ *
+ * - tape = list of numbers
+ * - head = the current read/write position (initially 0)
+ * - state = the current state of the machine (initially 1)
+ * - program = the program of the turing machine
+ *    - represented by a list of lists
+ *    - each inner list is a 5-tuple consisting of:
+ *      1. the current state
+ *      2. the character to read
+ *      3. the character to write
+ *      4. the move direction (0 = left, 1 = right)
+ *      5. the next state
+ *
+ * The state 0 is the halt state.
+ */
+
+/** creates a new turing machine based on the given tape, head, state and program */
+def newMachine :=
+  \tape.head.state.program.
+    (cons tape (cons head (cons state (cons program nil))))
+
+/** runs the given machine */
+def runMachine :=
+  Y (\rec.machine.
+     (eq (getState machine) 0)
+      machine
+      (rec (executeStep machine))
+  )
+
+/** executes one step of the given turing machine */
+def executeStep :=
+  \machine.
+     (eq (getState machine) 0)
+      machine
+      (nextMachine machine (getInstruction (getState machine)
+                                (getTapeContent machine)
+                                (getProgram machine)))
+
+/** creates a new machine based on the provided instruction */
+def nextMachine :=
+  \machine.instr.
+    (newMachine
+      (copyTapeWith (getTape machine) (getN 2 instr) (getHead machine))
+      ((eq (getN 3 instr) 0) (minus (getHead machine) 1) (plus (getHead machine) 1))
+      (getN 4 instr)
+      (getProgram machine)
+    )
+
+/** copies the given tape with the character at the specified index */
+def copyTapeWith :=
+  \tape.character.index.
+    Y (\rec.tape.counter.acc.
+       (isnil tape)
+        ((eq index counter)
+          (reverse (cons character acc))
+          ((gt index counter)
+            (rec nil (plus counter 1) (cons 0 acc))
+            (reverse acc)
+          )
+        )
+        (rec (tail tape)
+             (plus counter 1)
+             (cons ((ne counter index)
+               (head tape)
+               character
+             ) acc))
+    ) tape 0 nil
+
+
+/** returns the instruction for the given state */
+def getInstruction :=
+  \state.character.program.
+    Y (\rec.program.
+       (and (eq (head (head program)) state)
+            (eq (head (tail (head program))) character))
+              (head program)
+              (rec (tail program))
+    ) program
+
+/** returns the program of the given turing machine */
+def getProgram := \machine.head (applyN tail 3 machine)
+
+/** returns the head of the given turing machine */
+def getHead := \machine.head (tail machine)
+
+/** returns the state of the given turing machine */
+def getState := \machine.head (applyN tail 2 machine)
+
+/** returns the content of the tape at the current head position */
+def getTapeContent := \machine.getTapeContentAt (getTape machine) (getHead machine)
+
+/** returns the tape content at the specified index */
+def getTapeContentAt :=
+  Y (\rec.tape.index.
+     (isnil tape)
+      0
+      ((eq index 0)
+        (head tape)
+        (rec (tail tape) (minus index 1)))
+  )
+
+/** returns the tape of the given turing machine */
+def getTape := \machine.head machine
+
+/** returns the element at the n-th position */
+def getN := Y (\rec.index.list. (gt index 0) (rec (minus index 1) (tail list)) (head list))
+
+/**
+ * Example usage:
+ *
+ * def tape := []
+ * def program := [
+ *   [1, 0, 1, 1, 2],
+ *   [1, 2, 'x', 1, 0],
+ *   [2, 0, 2, 1, 3],
+ *   [3, 0, 1, 0, 1]
+ * ]
+ * def head := 0
+ * def start := 1
+ * def machine := newMachine tape head start program
+ * def main := runMachine machine 
+ */


### PR DESCRIPTION
Finally I had the time to write a turing machine in Morganey!

Theoretically it can execute any turing machine program (and thus shows that Morganey is turing complete!). 

Unfortunately the morganey program itself has a runtime complexity which is nearly exponential. This behavior is the result of the evaluation strategy "call-by-name" Morganey uses. It could be fixed by using the "call-by-need" strategy. 

But where does this come from? Every time a turing machine is executed in a particular state (lets call it state "n"), it also executes the machine in the previous state ("n - 1"). Because parameters are evaluated each time they are used, the machine in state "n" executes the machine in state "n - 1" not only once, but a few times. The machine in state "n - 1" does the same and so on. As one can imagine, the algorithm builds up a tree of turing machines.

The evaluation strategy "call-by-need" would fix that problem, because once the machine in state "n - 1" is calculated it would never have to be calculated again. So the machine in state "n" would calculate the machine in state "n - 1", where the machine in state "n - 1" would calculate the machine in state "n - 2" and so on.  If I've not messed up, this should reduce the runtime complexity to a linear behavior.

In contrast, executing a single step is fast. So it is possible to execute a single step, overwrite the initial turing machine with the newly calculated one and run it again and again.

I've added a brief explanation of the usage to the file.

