### PR TITLE
Make stdlib subproject build morganey module index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ jdk: oraclejdk7
 sudo: false
 scala:
   - 2.11.8
-script:
+before_script:
   - sbt clean compile
+script:
   - sbt test-only
   - sbt funtests
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ sudo: false
 scala:
   - 2.11.8
 script:
-  # - sbt retest
-  # - sbt funtests
-  - sbt build
+  - sbt retest
+  - sbt funtests
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ scala:
 script:
   - sbt retest
   - sbt funtests
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 notifications:
   email:
     - reximkut@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ sudo: false
 scala:
   - 2.11.8
 script:
-  - sbt retest
-  - sbt funtests
+  # - sbt retest
+  # - sbt funtests
+  - sbt build
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ sudo: false
 scala:
   - 2.11.8
 script:
-  - sbt retest
+  - sbt clean compile
+  - sbt test-only
   - sbt funtests
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ script:
 notifications:
   email:
     - reximkut@gmail.com
+cache:
+  directories:
+  - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,10 @@ lazy val commonSettings = Seq(
   version := "0.0.1",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
+  resolvers += Resolver.bintrayRepo("keddelzz", "maven"),
   libraryDependencies ++= Seq(
     "jline" % "jline" % "2.12.1",
+    "com.github.keddelzz.hidden-args" %% "hidden-args" % "0.0.1",
     "org.scalatest" % "scalatest_2.11" % "3.0.0" % "test",
     "org.mockito" % "mockito-core" % "2.2.28" % "test"
   ),
@@ -110,7 +112,6 @@ lazy val morganey = (project in file("."))
   .dependsOn(
     macros % dependencySettings,
     kernel % dependencySettings,
-    hiddenArgs,
     stdlib
   )
 
@@ -118,14 +119,12 @@ lazy val macros = (project in file("macros"))
   .settings(commonSettings :_*)
   .settings(macroSettings :_*)
   .dependsOn(
-    kernel % dependencySettings,
-    hiddenArgs
+    kernel % dependencySettings
   )
 
 lazy val kernel = (project in file("kernel"))
   .settings(commonSettings :_*)
   .settings(kernelSettings :_*)
-  .dependsOn(hiddenArgs)
 
 lazy val stdlib = (project in file("std"))
   .settings(commonSettings :_*)
@@ -135,6 +134,3 @@ lazy val funtests = (project in file("funtests"))
   .enablePlugins(BuildInfoPlugin)
   .settings(commonSettings :_*)
   .settings(funtestsSettings :_*)
-  .dependsOn(hiddenArgs)
-
-lazy val hiddenArgs = ProjectRef(uri("https://github.com/keddelzz/hidden-args.git"), "hiddenargs")

--- a/std/src/main/resources/morganey-index
+++ b/std/src/main/resources/morganey-index
@@ -1,6 +1,0 @@
-std/list.mgn
-std/prelude.mgn
-std/common.mgn
-std/math/arithmetic.mgn
-std/logic.mgn
-std/functions.mgn


### PR DESCRIPTION
Generate the module-index of Morganey during the sbt-task 'build'.

closes #304